### PR TITLE
feat: 회원가입 api 기본 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,17 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.1.0'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/web/stard/StardApplication.java
+++ b/src/main/java/com/web/stard/StardApplication.java
@@ -2,8 +2,10 @@ package com.web.stard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class StardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/web/stard/domain/member/api/MemberController.java
+++ b/src/main/java/com/web/stard/domain/member/api/MemberController.java
@@ -1,0 +1,26 @@
+package com.web.stard.domain.member.api;
+
+import com.web.stard.domain.member.application.MemberService;
+import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "회원가입")
+    @PostMapping
+    public ResponseEntity<MemberResponseDto.SignupResultDto> signUp(@RequestBody MemberRequestDto.SignupDto requestDTO) {
+        return ResponseEntity.ok(memberService.signUp(requestDTO));
+    }
+}

--- a/src/main/java/com/web/stard/domain/member/api/MemberController.java
+++ b/src/main/java/com/web/stard/domain/member/api/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @Operation(summary = "회원가입")
-    @PostMapping
+    @PostMapping("/join")
     public ResponseEntity<MemberResponseDto.SignupResultDto> signUp(@RequestBody MemberRequestDto.SignupDto requestDTO) {
         return ResponseEntity.ok(memberService.signUp(requestDTO));
     }

--- a/src/main/java/com/web/stard/domain/member/application/MemberService.java
+++ b/src/main/java/com/web/stard/domain/member/application/MemberService.java
@@ -1,0 +1,8 @@
+package com.web.stard.domain.member.application;
+
+import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
+
+public interface  MemberService {
+    MemberResponseDto.SignupResultDto signUp(MemberRequestDto.SignupDto requestDTO);
+}

--- a/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
@@ -1,0 +1,32 @@
+package com.web.stard.domain.member.application.impl;
+
+import com.web.stard.domain.member.application.MemberService;
+import com.web.stard.domain.member.domain.Member;
+import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
+import com.web.stard.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public MemberResponseDto.SignupResultDto signUp(MemberRequestDto.SignupDto requestDto) {
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        Member member = requestDto.toEntity(encodedPassword);
+
+        // 회원 정보 저장
+        Member savedMember = memberRepository.save(member);
+
+        return MemberResponseDto.SignupResultDto.from(savedMember);
+    }
+}

--- a/src/main/java/com/web/stard/domain/member/domain/Address.java
+++ b/src/main/java/com/web/stard/domain/member/domain/Address.java
@@ -1,0 +1,23 @@
+package com.web.stard.domain.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "address_id", nullable = false)
+    private Long id;
+
+    private String city;    // 시
+
+    private String district;    // 구
+}

--- a/src/main/java/com/web/stard/domain/member/domain/Interest.java
+++ b/src/main/java/com/web/stard/domain/member/domain/Interest.java
@@ -1,0 +1,28 @@
+package com.web.stard.domain.member.domain;
+
+import com.web.stard.domain.member.domain.enums.InterestField;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class Interest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interest_id", nullable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interest_field", nullable = false)
+    private InterestField interestField; // 관심 분야
+
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/web/stard/domain/member/domain/Member.java
+++ b/src/main/java/com/web/stard/domain/member/domain/Member.java
@@ -1,0 +1,46 @@
+package com.web.stard.domain.member.domain;
+
+import com.web.stard.domain.member.domain.enums.Role;
+import com.web.stard.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long id;
+
+    private String email;   // 이메일
+
+    private String password;    // 비밀번호
+
+    private String name;    // 이름
+
+    private String nickname;    // 닉네임
+
+    private String phone;   // 전화번호
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role; // 권한
+
+    @ColumnDefault("false")
+    @Column(name = "matching_study_allow", columnDefinition = "TINYINT(1)")
+    private boolean matchingStudyAllow; // 스터디 매칭 알림 여부
+
+    @ColumnDefault("0")
+    @Column(name = "report_count")
+    private double reportCount; // 누적 신고 수
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id")
+    private Address address;
+}

--- a/src/main/java/com/web/stard/domain/member/domain/Profile.java
+++ b/src/main/java/com/web/stard/domain/member/domain/Profile.java
@@ -1,0 +1,32 @@
+package com.web.stard.domain.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class Profile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_id", nullable = false)
+    private Long id;
+
+    @ColumnDefault("5.0")
+    private double credibility; // 신뢰도
+
+    private String introduce;   // 자기소개
+
+    @Column(name = "img_url")
+    private String imgUrl;  // 이미지 경로
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/web/stard/domain/member/domain/enums/InterestField.java
+++ b/src/main/java/com/web/stard/domain/member/domain/enums/InterestField.java
@@ -1,0 +1,13 @@
+package com.web.stard.domain.member.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InterestField {
+    취업, 자소서, 면접, 취미, 영어공부,
+    프로그래밍, 음악, 미술, 스포츠, 요리,
+    건강, 여행, 독서, 투자, 사회봉사,
+    뉴스, 기술동향, 건축, 한경, 블로그운영
+}

--- a/src/main/java/com/web/stard/domain/member/domain/enums/Role.java
+++ b/src/main/java/com/web/stard/domain/member/domain/enums/Role.java
@@ -1,0 +1,14 @@
+package com.web.stard.domain.member.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String roleValue;
+}

--- a/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
@@ -1,0 +1,55 @@
+package com.web.stard.domain.member.dto.request;
+
+import com.web.stard.domain.member.domain.Member;
+import com.web.stard.domain.member.domain.enums.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberRequestDto {
+
+    @Getter
+    @Builder
+    public static class SignupDto {
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Schema(example = "user@naver.com", description = "회원가입 이메일")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식에 맞지 않습니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입니다.")
+        @Schema(example = "user123!", description = "회원가입 비밀번호")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 8 ~ 15자 영문, 숫자, 특수문자 조합이어야 합니다.")
+        private String password;
+
+        @Size(min = 2, message = "이름은 2자 이상이어야 합니다.")
+        @Schema(example = "스타디", description = "회원 이름")
+        @NotBlank(message = "이름은 필수 입니다.")
+        private String name;
+
+        @Size(min = 2, message = "닉네임은 2자 이상이어야 합니다.")
+        @Schema(example = "스타", description = "회원 닉네임")
+        @NotBlank(message = "닉네임은 필수 입니다.")
+        private String nickname;
+
+        @Size(min = 7, message = "전화번호는 7자 이상이어야 합니다.")
+        @Schema(example = "010-1234-5678", description = "회원 전화번호")
+        @NotBlank(message = "전화번호는 필수 입니다.")
+        private String phone;
+
+        public Member toEntity(String encodedPassword){
+            return Member.builder()
+                    .email(email)
+                    .password(encodedPassword)
+                    .name(name)
+                    .nickname(nickname)
+                    .phone(phone)
+                    .role(Role.USER)
+                    .build();
+        }
+
+    }
+}

--- a/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
@@ -3,6 +3,7 @@ package com.web.stard.domain.member.dto.request;
 import com.web.stard.domain.member.domain.Member;
 import com.web.stard.domain.member.domain.enums.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -17,7 +18,7 @@ public class MemberRequestDto {
 
         @NotBlank(message = "이메일은 필수입니다.")
         @Schema(example = "user@naver.com", description = "회원가입 이메일")
-        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식에 맞지 않습니다.")
+        @Email(message = "이메일 형식에 맞지 않습니다.")
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입니다.")

--- a/src/main/java/com/web/stard/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/web/stard/domain/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,24 @@
+package com.web.stard.domain.member.dto.response;
+
+import com.web.stard.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class MemberResponseDto {
+
+    @Getter
+    @Builder
+    public static class SignupResultDto {
+        private Long id;
+        private LocalDateTime createdAt;
+
+        public static SignupResultDto from(Member member){
+            return SignupResultDto.builder()
+                    .id(member.getId())
+                    .createdAt(member.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/web/stard/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/web/stard/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.web.stard.domain.member.repository;
+
+import com.web.stard.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/web/stard/domain/test/api/TestController.java
+++ b/src/main/java/com/web/stard/domain/test/api/TestController.java
@@ -1,10 +1,13 @@
 package com.web.stard.domain.test.api;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class TestController {
+
+    @Hidden
     @GetMapping("/health")
     public String healthCheck() {
         return "I'm healthy";

--- a/src/main/java/com/web/stard/global/config/WebConfig.java
+++ b/src/main/java/com/web/stard/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.web.stard.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedHeaders("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowCredentials(true);
+    }
+}
+
+
+

--- a/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.web.stard.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/**").permitAll()
+                        .anyRequest().authenticated() // 다른 모든 요청은 인증 필요
+                );
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.web.stard.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info().title("STARD API").description("STARD API 명세").version("0.0.1");
+
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/com/web/stard/global/domain/BaseEntity.java
+++ b/src/main/java/com/web/stard/global/domain/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.web.stard.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/web/stard/global/dto/CommonResponse.java
+++ b/src/main/java/com/web/stard/global/dto/CommonResponse.java
@@ -1,0 +1,15 @@
+package com.web.stard.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CommonResponse {
+
+    SUCCESS(0, "Success"), FAIL(-1, "Fail");
+
+    final int code;
+
+    final String msg;
+}

--- a/src/main/java/com/web/stard/global/dto/Response.java
+++ b/src/main/java/com/web/stard/global/dto/Response.java
@@ -1,0 +1,135 @@
+package com.web.stard.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+
+@Component
+public class Response {
+
+    @Getter
+    @Builder
+    private static class Body {
+
+        private int state;
+        private String result;
+        private String massage;
+        private Object data;
+        private Object error;
+    }
+
+    public ResponseEntity<?> success(Object data, String msg, HttpStatus status) {
+        Body body = Body.builder()
+                .state(status.value())
+                .data(data)
+                .result("success")
+                .massage(msg)
+                .error(Collections.emptyList())
+                .build();
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * <p> 메세지만 가진 성공 응답을 반환한다.</p>
+     * <pre>
+     *     {
+     *         "state" : 200,
+     *         "result" : success,
+     *         "message" : message,
+     *         "data" : [],
+     *         "error" : []
+     *     }
+     * </pre>
+     *
+     * @param msg 응답 바디 message 필드에 포함될 정보
+     * @return 응답 객체
+     */
+    public ResponseEntity<?> success(String msg) {
+        return success(Collections.emptyList(), msg, HttpStatus.OK);
+    }
+
+    /**
+     * <p> 데이터만 가진 성공 응답을 반환한다.</p>
+     * <pre>
+     *     {
+     *         "state" : 200,
+     *         "result" : success,
+     *         "message" : null,
+     *         "data" : [{data1}, {data2}...],
+     *         "error" : []
+     *     }
+     * </pre>
+     *
+     * @param data 응답 바디 data 필드에 포함될 정보
+     * @return 응답 객체
+     */
+    public ResponseEntity<?> success(Object data) {
+        return success(data, null, HttpStatus.OK);
+    }
+
+    /**
+     * <p> 성공 응답만 반환한다. </p>
+     * <pre>
+     *     {
+     *         "state" : 200,
+     *         "result" : success,
+     *         "message" : null,
+     *         "data" : [],
+     *         "error" : []
+     *     }
+     * </pre>
+     *
+     * @return 응답 객체
+     */
+    public ResponseEntity<?> success() {
+        return success(Collections.emptyList(), null, HttpStatus.OK);
+    }
+
+    public ResponseEntity<?> fail(Object data, String msg, HttpStatus status) {
+        Body body = Body.builder()
+                .state(status.value())
+                .data(data)
+                .result("fail")
+                .massage(msg)
+                .error(Collections.emptyList())
+                .build();
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * <p> 메세지를 가진 실패 응답을 반환한다. </p>
+     * <pre>
+     *     {
+     *         "state" : HttpStatus Code,
+     *         "result" : fail,
+     *         "message" : message,
+     *         "data" : [],
+     *         "error" : [{error1}, {error2}...]
+     *     }
+     * </pre>
+     *
+     * @param msg 응답 바디 message 필드에 포함될 정보
+     * @param status 응답 바디 status 필드에 포함될 응답 상태 코드
+     * @return 응답 객체
+     */
+    public ResponseEntity<?> fail(String msg, HttpStatus status) {
+        return fail(Collections.emptyList(), msg, status);
+    }
+
+    public ResponseEntity<?> invalidFields(LinkedList<LinkedHashMap<String, String>> errors) {
+        Body body = Body.builder()
+                .state(HttpStatus.BAD_REQUEST.value())
+                .data(Collections.emptyList())
+                .result("fail")
+                .massage("")
+                .error(errors)
+                .build();
+        return ResponseEntity.ok(body);
+    }
+}

--- a/src/main/java/com/web/stard/global/dto/TokenInfo.java
+++ b/src/main/java/com/web/stard/global/dto/TokenInfo.java
@@ -1,0 +1,18 @@
+package com.web.stard.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class TokenInfo {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long refreshTokenExpirationTime;
+
+
+}

--- a/src/main/java/com/web/stard/global/error/CustomException.java
+++ b/src/main/java/com/web/stard/global/error/CustomException.java
@@ -1,0 +1,10 @@
+package com.web.stard.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    ErrorCode errorCode;
+}

--- a/src/main/java/com/web/stard/global/error/CustomExceptionHandler.java
+++ b/src/main/java/com/web/stard/global/error/CustomExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.web.stard.global.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponseEntity> handleCustomException(CustomException e){
+        return ErrorResponseEntity.toResponseEntity(e.getErrorCode());
+    }
+}

--- a/src/main/java/com/web/stard/global/error/ErrorCode.java
+++ b/src/main/java/com/web/stard/global/error/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.web.stard.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이메일이나 비밀번호 불일치"),
+    CONFLICT(HttpStatus.CONFLICT, "중복"),
+    MISMATCH_TOKEN(HttpStatus.BAD_REQUEST, "토큰 불일치"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰"),
+    INVALID_TOKEN(HttpStatus.FORBIDDEN, "토큰 검증 실패");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/web/stard/global/error/ErrorResponseEntity.java
+++ b/src/main/java/com/web/stard/global/error/ErrorResponseEntity.java
@@ -1,0 +1,22 @@
+package com.web.stard.global.error;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+@Data
+@Builder
+public class ErrorResponseEntity {
+
+    private int status;
+    private String message;
+
+    public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode e){
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ErrorResponseEntity.builder()
+                        .status(e.getHttpStatus().value())
+                        .message(e.getMessage())
+                        .build());
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #4 

## 📝 작업 내용
-   [feat: 공통 에러 처리 및 응답 형식 관련 코드 추가](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/489d2670d66bab40a859329c82c412efd7a2a58e)
- [feat: 회원 관련 도메인 클래스 추가](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/5d17b078c7a83c2f27a5ca4e5a5fc40dc4fddf81)
- [chore: Spring Security, Swagger 설정 파일 추가](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/95062c3064f9b1fa3488174ffc9f11d8c87dd915)
- [feat: 회원가입 api 기본 구현](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/3c8ad90b4092588c66d1d3655cc5e79b3a6d6fdf)
## 📚 Reference


## 💬 리뷰 요구사항
기본적인 회원가입 기능 먼저 구현해두었으니 이어서 작업하시면 될 것 같습니다. 
프론트엔드가 아닌 Swagger에서 요청을 보내고 테스트하시면 됩니다. http://localhost:8080/swagger-ui/index.html#/ 
중복 확인, 프로필 설정 등 추가 로직은 추후 구현할 예정입니다. 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
