### PR TITLE
refactor: member, auth 구분 및 예외 응답 통일

### DIFF
--- a/src/main/java/com/web/stard/domain/member/api/AuthController.java
+++ b/src/main/java/com/web/stard/domain/member/api/AuthController.java
@@ -34,10 +34,11 @@ public class AuthController {
         return ResponseEntity.ok(authService.checkEmailDuplicate(requestDto.email()));
     }
 
-    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
+    @Operation(summary = "닉네임 중복 확인", description = "** memberId 없이 nickname만 전달해주세요!!! (추후 수정 예정) **\n\n" +
+            "입력한 닉네임을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
             "사용 가능하면 true, 이미 사용 중이면 false 값을 반환합니다.")
     @PostMapping("/check-nickname")
-    public ResponseEntity<Boolean> checkDuplicateNickname(@Valid @RequestBody MemberRequestDto.NicknameDto requestDto) {
+    public ResponseEntity<Boolean> checkDuplicateNickname(@Valid @RequestBody MemberRequestDto.EditNicknameDto requestDto) {
         return ResponseEntity.ok(authService.checkNicknameDuplicate(requestDto.getNickname()));
     }
 

--- a/src/main/java/com/web/stard/domain/member/api/AuthController.java
+++ b/src/main/java/com/web/stard/domain/member/api/AuthController.java
@@ -1,38 +1,72 @@
 package com.web.stard.domain.member.api;
 
-import com.web.stard.domain.member.application.MemberService;
+import com.web.stard.domain.member.application.AuthService;
 import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
 import com.web.stard.global.dto.TokenInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/members/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final MemberService memberService;
+    private final AuthService authService;
 
+    // 회원가입
+    @Operation(summary = "회원가입")
+    @PostMapping(value = "/join", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<MemberResponseDto.SignupResultDto> signUp(@RequestPart(value = "file", required = false) MultipartFile file,
+                                                                    @Valid @RequestPart(name = "requestDto") MemberRequestDto.SignupDto requestDto) {
+        return ResponseEntity.ok(authService.signUp(file, requestDto));
+    }
+
+    @Operation(summary = "이메일 중복 확인", description = "입력한 이메일을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
+            "사용 가능하면 true, 이미 사용 중이면 false 값을 반환합니다.")
+    @PostMapping("/check-email")
+    public ResponseEntity<Boolean> checkDuplicateID(@Valid @RequestBody MemberRequestDto.EmailRequestDto requestDto) {
+        return ResponseEntity.ok(authService.checkEmailDuplicate(requestDto.email()));
+    }
+
+    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
+            "사용 가능하면 true, 이미 사용 중이면 false 값을 반환합니다.")
+    @PostMapping("/check-nickname")
+    public ResponseEntity<Boolean> checkDuplicateNickname(@Valid @RequestBody MemberRequestDto.NicknameDto requestDto) {
+        return ResponseEntity.ok(authService.checkNicknameDuplicate(requestDto.getNickname()));
+    }
+
+    @Operation(summary = "회원가입 추가 정보 저장",
+            description = "회원가입 후, 관심 분야를 저장합니다.(선택사항)")
+    @PostMapping("/join/additional-info")
+    public ResponseEntity<MemberResponseDto.AdditionalInfoResultDto> saveAdditionalInfo(@Valid @RequestBody MemberRequestDto.AdditionalInfoRequestDto requestDto) {
+        MemberResponseDto.AdditionalInfoResultDto result = authService.saveAdditionalInfo(requestDto);
+        return ResponseEntity.ok(result);
+    }
+    
+    // 로그인
     @PostMapping("/sign-in")
     @Operation(summary = "로그인")
     public ResponseEntity<TokenInfo> signIn(@Valid @RequestBody MemberRequestDto.SignInDto request) {
-        return ResponseEntity.ok(memberService.signIn(request));
+        return ResponseEntity.ok(authService.signIn(request));
     }
 
     @PostMapping("/auth-codes")
     @Operation(summary = "인증 번호 전송")
     public ResponseEntity<?> sendAuthCode(@Valid @RequestBody MemberRequestDto.EmailRequestDto request) throws Exception {
-        memberService.sendAuthCode(request.email());
+        authService.sendAuthCode(request.email());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/auth-codes/verify")
     @Operation(summary = "인증 번호 검증")
     public ResponseEntity<?> validAuthCode(@Valid @RequestBody MemberRequestDto.AuthCodeRequestDto request) throws Exception {
-        memberService.validAuthCode(request);
+        authService.validAuthCode(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/web/stard/domain/member/api/MemberController.java
+++ b/src/main/java/com/web/stard/domain/member/api/MemberController.java
@@ -6,10 +6,8 @@ import com.web.stard.domain.member.dto.response.MemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/members")
@@ -17,35 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
     private final MemberService memberService;
-
-    @Operation(summary = "회원가입")
-    @PostMapping(value = "/join", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<MemberResponseDto.SignupResultDto> signUp(@RequestPart(value = "file", required = false) MultipartFile file,
-                                                                    @Valid @RequestPart MemberRequestDto.SignupDto requestDTO) {
-        return ResponseEntity.ok(memberService.signUp(file, requestDTO));
-    }
-
-    @Operation(summary = "이메일 중복 확인", description = "입력한 이메일을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
-            "사용 가능하면 true, 이미 사용 중이면 false 값을 반환합니다.")
-    @GetMapping("/check-email")
-    public ResponseEntity<Boolean> checkDuplicateID(@RequestParam(name = "email") String email) {
-        return ResponseEntity.ok(memberService.checkEmailDuplicate(email));
-    }
-
-    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임을 다른 사용자가 사용 중인지 확인합니다.\n\n" +
-            "사용 가능하면 true, 이미 사용 중이면 false 값을 반환합니다.")
-    @GetMapping("/check-nickname")
-    public ResponseEntity<Boolean> checkDuplicateNickname(@RequestParam(name = "nickname") String nickname) {
-        return ResponseEntity.ok(memberService.checkNicknameDuplicate(nickname));
-    }
-
-    @Operation(summary = "회원가입 추가 정보 저장",
-            description = "회원가입 후, 관심 분야를 저장합니다.(선택사항)")
-    @PostMapping("/join/additional-info")
-    public ResponseEntity<MemberResponseDto.AdditionalInfoResultDto> saveAdditionalInfo(@Valid @RequestBody MemberRequestDto.AdditionalInfoRequestDto requestDto) {
-        MemberResponseDto.AdditionalInfoResultDto result = memberService.saveAdditionalInfo(requestDto);
-        return ResponseEntity.ok(result);
-    }
 
     @Operation(summary = "개인정보 반환")
     @GetMapping("/edit")
@@ -55,19 +24,19 @@ public class MemberController {
 
     @Operation(summary = "비밀번호 변경")
     @PostMapping("/edit/password")
-    public ResponseEntity<String> editPassword(@RequestBody MemberRequestDto.EditPasswordDto requestDto) {
+    public ResponseEntity<String> editPassword(@Valid @RequestBody MemberRequestDto.EditPasswordDto requestDto) {
         return memberService.editPassword(requestDto);
     }
 
     @Operation(summary = "닉네임 변경")
     @PostMapping("/edit/nickname")
-    public ResponseEntity<MemberResponseDto.EditNicknameResponseDto> editNickname(@RequestBody MemberRequestDto.EditNicknameDto requestDto) {
+    public ResponseEntity<MemberResponseDto.EditNicknameResponseDto> editNickname(@Valid @RequestBody MemberRequestDto.EditNicknameDto requestDto) {
         return ResponseEntity.ok(memberService.editNickname(requestDto)); // TODO 로그인 한 사용자 가져오기
     }
 
     @Operation(summary = "관심분야 변경")
     @PostMapping("/edit/interests")
-    public ResponseEntity<MemberResponseDto.EditInterestResponseDto> editInterests(@RequestBody MemberRequestDto.AdditionalInfoRequestDto requestDto) {
+    public ResponseEntity<MemberResponseDto.EditInterestResponseDto> editInterests(@Valid @RequestBody MemberRequestDto.AdditionalInfoRequestDto requestDto) {
         return ResponseEntity.ok(memberService.editInterest(requestDto));
     }
 

--- a/src/main/java/com/web/stard/domain/member/application/AuthService.java
+++ b/src/main/java/com/web/stard/domain/member/application/AuthService.java
@@ -1,0 +1,22 @@
+package com.web.stard.domain.member.application;
+
+import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
+import com.web.stard.global.dto.TokenInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AuthService {
+    MemberResponseDto.SignupResultDto signUp(MultipartFile file, MemberRequestDto.SignupDto requestDto);
+
+    boolean checkEmailDuplicate(String email);
+
+    boolean checkNicknameDuplicate(String nickname);
+
+    MemberResponseDto.AdditionalInfoResultDto saveAdditionalInfo(MemberRequestDto.AdditionalInfoRequestDto requestDto);
+
+    TokenInfo signIn(MemberRequestDto.SignInDto request);
+
+    void sendAuthCode(String email) throws Exception;
+
+    void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception;
+}

--- a/src/main/java/com/web/stard/domain/member/application/MemberService.java
+++ b/src/main/java/com/web/stard/domain/member/application/MemberService.java
@@ -1,21 +1,10 @@
 package com.web.stard.domain.member.application;
 
 import com.web.stard.domain.member.dto.request.MemberRequestDto;
-import com.web.stard.domain.member.dto.request.MemberRequestDto.SignInDto;
 import com.web.stard.domain.member.dto.response.MemberResponseDto;
-import com.web.stard.global.dto.TokenInfo;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
-    MemberResponseDto.SignupResultDto signUp(MultipartFile file, MemberRequestDto.SignupDto requestDTO);
-
-    boolean checkEmailDuplicate(String email);
-
-    boolean checkNicknameDuplicate(String nickname);
-
-    MemberResponseDto.AdditionalInfoResultDto saveAdditionalInfo(MemberRequestDto.AdditionalInfoRequestDto requestDto);
-
     MemberResponseDto.InfoDto getInfo(Long id);
 
     boolean checkCurrentPassword(String currentPassword, String password);
@@ -25,11 +14,4 @@ public interface MemberService {
     MemberResponseDto.EditNicknameResponseDto editNickname(MemberRequestDto.EditNicknameDto requestDto);
 
     MemberResponseDto.EditInterestResponseDto editInterest(MemberRequestDto.AdditionalInfoRequestDto requestDto);
-
-    TokenInfo signIn(SignInDto request);
-
-
-    void sendAuthCode(String email) throws Exception;
-
-    void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception;
 }

--- a/src/main/java/com/web/stard/domain/member/application/impl/AuthServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/application/impl/AuthServiceImpl.java
@@ -1,0 +1,175 @@
+package com.web.stard.domain.member.application.impl;
+
+import com.web.stard.domain.member.application.AuthService;
+import com.web.stard.domain.member.domain.Interest;
+import com.web.stard.domain.member.domain.Member;
+import com.web.stard.domain.member.domain.Profile;
+import com.web.stard.domain.member.domain.enums.InterestField;
+import com.web.stard.domain.member.dto.request.MemberRequestDto;
+import com.web.stard.domain.member.dto.response.MemberResponseDto;
+import com.web.stard.domain.member.repository.InterestRepository;
+import com.web.stard.domain.member.repository.MemberRepository;
+import com.web.stard.global.config.aws.S3Manager;
+import com.web.stard.global.config.security.JwtTokenProvider;
+import com.web.stard.global.dto.TokenInfo;
+import com.web.stard.global.exception.CustomException;
+import com.web.stard.global.exception.error.ErrorCode;
+import com.web.stard.global.utils.EmailUtils;
+import com.web.stard.global.utils.RedisUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final MemberRepository memberRepository;
+    private final InterestRepository interestRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final S3Manager s3Manager;
+    private final RedisUtils redisUtils;
+    private final EmailUtils emailUtils;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManager authenticationManager;
+
+    /**
+     * 회원가입
+     *
+     * @param file              프로필 이미지 파일
+     * @param requestDto        email, password, nickname
+     *                          이메일    비밀번호    닉네임
+     * @return SignupResultDto  memberId, createdAt
+     *                          멤버 id    생성일시
+     */
+    @Override
+    @Transactional
+    public MemberResponseDto.SignupResultDto signUp(MultipartFile file, MemberRequestDto.SignupDto requestDto) {
+
+        if (!checkEmailDuplicate(requestDto.getEmail())) {
+           throw new CustomException(ErrorCode.EMAIL_CONFLICT);
+        };
+        if (!checkNicknameDuplicate(requestDto.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_CONFLICT);
+        }
+
+        String fileUrl = null;
+
+        // UUID 생성 및 키 이름 생성
+        if (file != null && !file.isEmpty()) {
+            UUID uuid = UUID.randomUUID();
+            String keyName = s3Manager.generateProfileKeyName(uuid);
+
+            // S3에 파일 업로드
+            fileUrl = s3Manager.uploadFile(keyName, file);
+        }
+
+        // 프로필 생성
+        Profile profile = Profile.builder()
+                .credibility(5.0)
+                .imgUrl(fileUrl)
+                .build();
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        // 회원 정보 저장
+        Member member = requestDto.toEntity(encodedPassword, profile);
+        Member savedMember = memberRepository.save(member);
+
+        return MemberResponseDto.SignupResultDto.from(savedMember);
+    }
+
+    /**
+     * 이메일 중복 확인
+     *
+     * @param email     중복 체크할 이메일
+     * @return boolean  이메일이 중복되지 않으면 true, 중복되면 false
+     */
+    @Override
+    public boolean checkEmailDuplicate(String email) {
+        return !memberRepository.existsByEmail(email);
+    }
+
+    /**
+     * 닉네임 중복 확인
+     *
+     * @param nickname  중복 체크할 닉네임
+     * @return boolean  닉네임이 중복되지 않으면 true, 중복되면 false
+     */
+    @Override
+    public boolean checkNicknameDuplicate(String nickname) {
+        return !memberRepository.existsByNickname(nickname);
+    }
+
+
+    /**
+     * 회원가입 추가 정보 저장
+     *
+     * @param requestDto        memberId, interests
+     *                          멤버 id    관심분야
+     * @return AdditionalInfoResultDto  memberId, interests
+     *                                  멤버 id    관심분야
+     */
+    @Override
+    @Transactional
+    public MemberResponseDto.AdditionalInfoResultDto saveAdditionalInfo(MemberRequestDto.AdditionalInfoRequestDto requestDto) {
+        Member member = memberRepository.findById(requestDto.getMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 관심 분야 저장
+        if (requestDto.getInterests() != null && !requestDto.getInterests().isEmpty()) {
+            requestDto.getInterests().forEach(interest -> {
+                Interest interestEntity = Interest.builder()
+                        .interestField(InterestField.find(interest))
+                        .member(member)
+                        .build();
+                interestRepository.save(interestEntity);
+            });
+        }
+
+        // 회원 정보 저장
+        memberRepository.save(member);
+
+        return MemberResponseDto.AdditionalInfoResultDto.of(member);
+    }
+
+    /**
+     * 로그인
+     *
+     * @param request 로그인 정보
+     * @return TokenInfo 토큰 정보
+     */
+    @Override
+    @Transactional
+    public TokenInfo signIn(MemberRequestDto.SignInDto request) {
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.email(), request.password());
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+            redisUtils.setData(request.email(), tokenInfo.getRefreshToken(), tokenInfo.getRefreshTokenExpirationTime());
+            return tokenInfo;
+        } catch (BadCredentialsException e) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    @Override
+    public void sendAuthCode(String email) throws Exception {
+        emailUtils.send(email);
+    }
+
+    @Override
+    public void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception {
+        emailUtils.validAuthCode(request.email(), request.authCode());
+    }
+
+}

--- a/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
@@ -48,6 +48,7 @@ public class MemberServiceImpl implements MemberService {
      * @return InfoDto   nickname, interests
      *                   닉네임     관심분야
      */
+    @Transactional(readOnly = true)
     @Override
     public MemberResponseDto.InfoDto getInfo(Long memberId) {
         // 회원 정보 반환

--- a/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/application/impl/MemberServiceImpl.java
@@ -3,143 +3,32 @@ package com.web.stard.domain.member.application.impl;
 import com.web.stard.domain.member.application.MemberService;
 import com.web.stard.domain.member.domain.Interest;
 import com.web.stard.domain.member.domain.Member;
-import com.web.stard.domain.member.domain.Profile;
 import com.web.stard.domain.member.domain.enums.InterestField;
 import com.web.stard.domain.member.dto.request.MemberRequestDto;
-import com.web.stard.domain.member.dto.request.MemberRequestDto.SignInDto;
 import com.web.stard.domain.member.dto.response.MemberResponseDto;
 import com.web.stard.domain.member.repository.InterestRepository;
 import com.web.stard.domain.member.repository.MemberRepository;
-import com.web.stard.global.config.aws.S3Manager;
-import com.web.stard.global.config.security.JwtTokenProvider;
-import com.web.stard.global.dto.TokenInfo;
 import com.web.stard.global.exception.CustomException;
 import com.web.stard.global.exception.error.ErrorCode;
-import com.web.stard.global.utils.EmailUtils;
-import com.web.stard.global.utils.RedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.UUID;
 
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
-    private final RedisUtils redisUtils;
-    private final EmailUtils emailUtils;
-    private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final InterestRepository interestRepository;
     private final PasswordEncoder passwordEncoder;
-    private final S3Manager s3Manager;
-    private final AuthenticationManager authenticationManager;
-
-    /**
-     * 회원가입
-     *
-     * @param file              프로필 이미지 파일
-     * @param requestDto        email, password, nickname
-     *                          이메일    비밀번호    닉네임
-     * @return SignupResultDto  memberId, createdAt
-     *                          멤버 id    생성일시
-     */
-    @Override
-    public MemberResponseDto.SignupResultDto signUp(MultipartFile file, MemberRequestDto.SignupDto requestDto) {
-
-        String fileUrl = null;
-
-        // UUID 생성 및 키 이름 생성
-        if (file != null && !file.isEmpty()) {
-            UUID uuid = UUID.randomUUID();
-            String keyName = s3Manager.generateProfileKeyName(uuid);
-
-            // S3에 파일 업로드
-            fileUrl = s3Manager.uploadFile(keyName, file);
-        }
-
-        // 프로필 생성
-        Profile profile = Profile.builder()
-                .credibility(5.0)
-                .imgUrl(fileUrl)
-                .build();
-
-        // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
-
-        // 회원 정보 저장
-        Member member = requestDto.toEntity(encodedPassword, profile);
-        Member savedMember = memberRepository.save(member);
-
-        return MemberResponseDto.SignupResultDto.from(savedMember);
-    }
-
-    /**
-     * 이메일 중복 확인
-     *
-     * @param email     중복 체크할 이메일
-     * @return boolean  이메일이 중복되지 않으면 true, 중복되면 false
-     */
-    @Override
-    public boolean checkEmailDuplicate(String email) {
-        return !memberRepository.existsByEmail(email);
-    }
-
-    /**
-     * 닉네임 중복 확인
-     *
-     * @param nickname  중복 체크할 닉네임
-     * @return boolean  닉네임이 중복되지 않으면 true, 중복되면 false
-     */
-    @Override
-    public boolean checkNicknameDuplicate(String nickname) {
-        return !memberRepository.existsByNickname(nickname);
-    }
-
-
-    /**
-     * 회원가입 추가 정보 저장
-     *
-     * @param requestDto        memberId, interests
-     *                          멤버 id    관심분야
-     * @return AdditionalInfoResultDto  memberId, interests
-     *                                  멤버 id    관심분야
-     */
-    @Override
-    public MemberResponseDto.AdditionalInfoResultDto saveAdditionalInfo(MemberRequestDto.AdditionalInfoRequestDto requestDto) {
-        Member member = memberRepository.findById(requestDto.getMemberId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        // 관심 분야 저장
-        if (requestDto.getInterests() != null && !requestDto.getInterests().isEmpty()) {
-            requestDto.getInterests().forEach(interest -> {
-                Interest interestEntity = Interest.builder()
-                        .interestField(InterestField.find(interest))
-                        .member(member)
-                        .build();
-                interestRepository.save(interestEntity);
-            });
-        }
-
-        // 회원 정보 저장
-        memberRepository.save(member);
-
-        return MemberResponseDto.AdditionalInfoResultDto.of(member);
-    }
 
     /**
      * 현재 비밀번호 확인
@@ -174,6 +63,7 @@ public class MemberServiceImpl implements MemberService {
      * @param requestDto 사용자 고유 id, password 비밀번호
      * @return 없음
      */
+    @Transactional
     @Override
     public ResponseEntity<String> editPassword(MemberRequestDto.EditPasswordDto requestDto) {
         // 회원 정보 반환
@@ -199,12 +89,18 @@ public class MemberServiceImpl implements MemberService {
      * @param requestDto                사용자 고유 id, nickname 닉네임
      * @return EditNicknameResponseDto  nickname 닉네임, message 성공 메시지
      */
+    @Transactional
     @Override
     public MemberResponseDto.EditNicknameResponseDto editNickname(MemberRequestDto.EditNicknameDto requestDto) {
         // 회원 정보 반환
         Member info = memberRepository.findById(requestDto.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
+        // 닉네임 중복 확인
+        if (memberRepository.existsByNickname(requestDto.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_CONFLICT);
+        }
+        
         // 닉네임 변경
         info.updateNickname(requestDto.getNickname());
 
@@ -255,36 +151,6 @@ public class MemberServiceImpl implements MemberService {
         });
 
         return MemberResponseDto.EditInterestResponseDto.of(interests);
-    }
-
-    /**
-     * 로그인
-     *
-     * @param request 로그인 정보
-     * @return TokenInfo 토큰 정보
-     */
-    @Override
-    @Transactional
-    public TokenInfo signIn(SignInDto request) {
-        try {
-            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.email(), request.password());
-            Authentication authentication = authenticationManager.authenticate(authenticationToken);
-            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
-            redisUtils.setData(request.email(), tokenInfo.getRefreshToken(), tokenInfo.getRefreshTokenExpirationTime());
-            return tokenInfo;
-        } catch (BadCredentialsException e) {
-            throw new CustomException(ErrorCode.INVALID_PASSWORD);
-        }
-    }
-
-    @Override
-    public void sendAuthCode(String email) throws Exception {
-        emailUtils.send(email);
-    }
-
-    @Override
-    public void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception {
-        emailUtils.validAuthCode(request.email(), request.authCode());
     }
 
 }

--- a/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
@@ -118,14 +118,4 @@ public class MemberRequestDto {
         private String nickname;
     }
 
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class NicknameDto {
-        @Size(min = 2, message = "닉네임은 2자 이상이어야 합니다.")
-        @Schema(example = "스타", description = "회원 닉네임")
-        @NotBlank(message = "닉네임은 필수 입니다.")
-        private String nickname;
-    }
-
 }

--- a/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/web/stard/domain/member/dto/request/MemberRequestDto.java
@@ -118,4 +118,14 @@ public class MemberRequestDto {
         private String nickname;
     }
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NicknameDto {
+        @Size(min = 2, message = "닉네임은 2자 이상이어야 합니다.")
+        @Schema(example = "스타", description = "회원 닉네임")
+        @NotBlank(message = "닉네임은 필수 입니다.")
+        private String nickname;
+    }
+
 }

--- a/src/main/java/com/web/stard/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/web/stard/global/exception/CustomExceptionHandler.java
@@ -1,14 +1,38 @@
 package com.web.stard.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class CustomExceptionHandler {
 
+    // CustomException에 대한 처리
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponseEntity> handleCustomException(CustomException e) {
         return ErrorResponseEntity.toResponseEntity(e.getErrorCode());
+    }
+
+    // @Valid 유효성 검사 실패 시 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponseEntity> handleValidationException(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();  // 필드별 오류 메시지를 담을 Map 생성
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());  // 필드 이름과 메시지 저장
+        }
+
+        ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Validation failed")
+                .errors(errors)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/src/main/java/com/web/stard/global/exception/ErrorResponseEntity.java
+++ b/src/main/java/com/web/stard/global/exception/ErrorResponseEntity.java
@@ -1,9 +1,12 @@
 package com.web.stard.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.web.stard.global.exception.error.ErrorCode;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
 
 @Data
 @Builder
@@ -11,6 +14,8 @@ public class ErrorResponseEntity {
 
     private int status;
     private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, String> errors;
 
     public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode e) {
         return ResponseEntity

--- a/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
@@ -8,9 +8,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이메일이나 비밀번호 불일치"),
-    CONFLICT(HttpStatus.CONFLICT, "중복"),
+    EMAIL_CONFLICT(HttpStatus.CONFLICT, "중복된 이메일입니다."),
+    NICKNAME_CONFLICT(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     MISMATCH_TOKEN(HttpStatus.BAD_REQUEST, "토큰 불일치"),
 
     //Jwt
@@ -33,7 +35,7 @@ public enum ErrorCode {
     INVALID_OR_EXPIRED_AUTH_CODE(HttpStatus.NOT_FOUND, "이메일을 잘못 입력했거나 인증 시간이 만료되었습니다."),
 
     // Post
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다.")
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
 
     ;
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #

## 📝 작업 내용
-   [refactor: 회원가입, 로그인 관련 로직을 Member에서 Auth로 이동](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/3d356df9efe2a9aacc73b1d2eb2c0eed362fc9ae)
    - 닉네임 및 이메일 중복 확인 요청 시 입력값 유효성 검사 추가
    - 회원가입 시 이메일 및 닉네임 중복을 재확인하는 로직 추가
    - 닉네임 변경 시 중복 확인 로직 추가    
<br/>

- [refactor:](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/66fcc077ce52faafb2c33ee40fe85bb02f7b34eb) @Valid [유효성 검사 실패 시 사용자 정의 오류 응답 반환](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/66fcc077ce52faafb2c33ee40fe85bb02f7b34eb)
   - 변경 전
![image](https://github.com/user-attachments/assets/b244edc5-ab89-46b2-bc52-4c716c48d443)
   - 변경 후
![image](https://github.com/user-attachments/assets/61f31071-6c5c-41e6-a3a1-24929c10d2ae)

## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
