### PR TITLE
feat: 스터디 팀블로그 - 커뮤니티 게시글 기능 구현 (2)

### DIFF
--- a/src/main/java/com/web/stard/domain/member/api/MemberController.java
+++ b/src/main/java/com/web/stard/domain/member/api/MemberController.java
@@ -9,8 +9,10 @@ import com.web.stard.domain.member.domain.dto.request.MemberRequestDto;
 import com.web.stard.domain.member.domain.dto.response.MemberResponseDto;
 import com.web.stard.domain.teamBlog.domain.dto.response.ScheduleResponseDto;
 import com.web.stard.domain.study.domain.dto.response.StudyResponseDto;
+import com.web.stard.domain.teamBlog.domain.dto.response.StudyPostResponseDto;
 import com.web.stard.domain.teamBlog.domain.dto.response.ToDoResponseDto;
 import com.web.stard.domain.teamBlog.service.ScheduleService;
+import com.web.stard.domain.teamBlog.service.StudyPostService;
 import com.web.stard.domain.teamBlog.service.ToDoService;
 import com.web.stard.global.domain.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,6 +35,7 @@ public class MemberController {
     private final PostService postService;
     private final ToDoService toDoService;
     private final ScheduleService scheduleService;
+    private final StudyPostService studyPostService;
 
     @Operation(summary = "개인정보 반환")
     @GetMapping("/edit")
@@ -134,5 +137,13 @@ public class MemberController {
                                                                                         @RequestParam(name = "year") int year,
                                                                                         @RequestParam(name = "month") int month) {
         return ResponseEntity.ok(scheduleService.getAllScheduleListByStudy(studyId, member, year, month));
+    }
+
+    @Operation(summary = "사용자가 작성한 스터디 별 팀블로그 커뮤니티 게시글 조회")
+    @GetMapping("/study-posts/{studyId}")
+    public ResponseEntity<StudyPostResponseDto.StudyPostListDto> getStudyPostListByStudy(@CurrentMember Member member,
+                                                                                         @PathVariable(name = "studyId") Long studyId,
+                                                                                         @RequestParam(value = "page", defaultValue = "1", required = false) int page) {
+        return ResponseEntity.ok(studyPostService.getMemberStudyPostListByStudy(studyId, member, page));
     }
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
@@ -67,4 +67,14 @@ public class StudyPostController {
                                                                                   @RequestParam(value = "page", defaultValue = "1", required = false) int page) {
         return ResponseEntity.ok(studyPostService.getStudyPostList(studyId, member, page));
     }
+
+    @Operation(summary = "스터디 팀블로그 게시글 키워드 검색")
+    @GetMapping("/search")
+    public ResponseEntity<StudyPostResponseDto.StudyPostListDto> searchStudyPost(@CurrentMember Member member,
+                                                                                 @PathVariable(name = "studyId") Long studyId,
+                                                                                 @RequestParam(name = "keyword") String keyword,
+                                                                                 @RequestParam(value = "page", defaultValue = "1", required = false) int page) {
+        return ResponseEntity.ok(studyPostService.searchStudyPost(studyId, keyword, member, page));
+    }
+
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
@@ -77,4 +77,11 @@ public class StudyPostController {
         return ResponseEntity.ok(studyPostService.searchStudyPost(studyId, keyword, member, page));
     }
 
+    @Operation(summary = "스터디 팀블로그 게시글 파일 다운로드")
+    @GetMapping("/download/{studyPostFileId}")
+    public ResponseEntity<byte[]> downloadFile(@CurrentMember Member member,
+                                               @PathVariable(name = "studyId") Long studyId,
+                                               @PathVariable(name = "studyPostFileId") Long studyPostFileId) {
+        return studyPostService.downloadFile(studyId, studyPostFileId, member);
+    }
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/StudyPostController.java
@@ -59,4 +59,12 @@ public class StudyPostController {
                                                                                 @PathVariable(name = "studyPostId") Long studyPostId) {
         return ResponseEntity.ok(studyPostService.getStudyPostDetail(studyId, studyPostId, member));
     }
+
+    @Operation(summary = "스터디 팀블로그 게시글 목록 조회")
+    @GetMapping
+    public ResponseEntity<StudyPostResponseDto.StudyPostListDto> getStudyPostList(@CurrentMember Member member,
+                                                                                  @PathVariable(name = "studyId") Long studyId,
+                                                                                  @RequestParam(value = "page", defaultValue = "1", required = false) int page) {
+        return ResponseEntity.ok(studyPostService.getStudyPostList(studyId, member, page));
+    }
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/StudyPostResponseDto.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/StudyPostResponseDto.java
@@ -2,9 +2,12 @@ package com.web.stard.domain.teamBlog.domain.dto.response;
 
 import com.web.stard.domain.teamBlog.domain.entity.StudyPost;
 import com.web.stard.domain.teamBlog.domain.entity.StudyPostFile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class StudyPostResponseDto {
@@ -12,8 +15,13 @@ public class StudyPostResponseDto {
     @Getter
     @Builder
     public static class FileDto {
+        @Schema(description = "팀블로그 게시글의 파일 아이디")
         private Long studyPostFileId;
+
+        @Schema(description = "팀블로그 게시글 파일 명")
         private String fileName;
+
+        @Schema(description = "팀블로그 게시글 파일 경로")
         private String fileUrl;
 
         public static FileDto of(StudyPostFile studyPostFile) {
@@ -28,18 +36,46 @@ public class StudyPostResponseDto {
     @Getter
     @Builder
     public static class StudyPostDto {
+        @Schema(description = "팀블로그 게시글 아이디")
         private Long studyPostId;
+
+        @Schema(description = "해당 스터디 아이디")
         private Long studyId;
+
+        @Schema(description = "팀블로그 게시글 작성자")
         private String writer;
+
+        @Schema(description = "팀블로그 게시글 프로필 이미지 경로")
         private String profileImg;
+
+        @Schema(description = "팀블로그 게시글 작성 시간")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "팀블로그 게시글 수정 시간")
+        private LocalDateTime updatedAt;
+
+        @Schema(description = "팀블로그 게시글 제목")
         private String title;
+
+        @Schema(description = "팀블로그 게시글 내용")
         private String content;
+
+        @Schema(description = "팀블로그 게시글 파일 리스트")
         private List<FileDto> fileUrl;
+
+        @Schema(description = "팀블로그 게시글 조회수")
         private int hit;
+
+        @Schema(description = "팀블로그 게시글 스크랩 개수")
         private int scrapCount;
+
+        @Schema(description = "팀블로그 게시글 작성자 여부")
         private boolean isAuthor;
 
-        public static StudyPostDto from(StudyPost studyPost, int scrapCount, boolean isAuthor) {
+        @Schema(description = "팀블로그 게시글 스크랩 여부")
+        private boolean existsScrap;
+
+        public static StudyPostDto from(StudyPost studyPost, int scrapCount, boolean isAuthor, boolean existsScrap) {
             List<FileDto> file = (studyPost.getFiles() != null) ? studyPost.getFiles().stream().map(FileDto::of).toList() : null;
 
             return StudyPostDto.builder()
@@ -47,12 +83,95 @@ public class StudyPostResponseDto {
                     .studyId(studyPost.getStudy().getId())
                     .writer(studyPost.getStudyMember().getMember().getNickname())
                     .profileImg(studyPost.getStudyMember().getMember().getProfile().getImgUrl())
+                    .createdAt(studyPost.getCreatedAt())
+                    .updatedAt(studyPost.getUpdatedAt())
                     .title(studyPost.getTitle())
                     .content(studyPost.getContent())
                     .fileUrl(file)
                     .hit(studyPost.getHit())
                     .scrapCount(scrapCount)
                     .isAuthor(isAuthor)
+                    .existsScrap(existsScrap)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class StudyPostItem {
+        @Schema(description = "팀블로그 게시글 아이디")
+        private Long studyPostId;
+
+        @Schema(description = "팀블로그 게시글 작성자")
+        private String writer;
+
+        @Schema(description = "팀블로그 게시글 프로필 이미지 경로")
+        private String profileImg;
+
+        @Schema(description = "팀블로그 게시글 작성 시간")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "팀블로그 게시글 수정 시간")
+        private LocalDateTime updatedAt;
+
+        @Schema(description = "팀블로그 게시글 제목")
+        private String title;
+
+        @Schema(description = "팀블로그 게시글 조회수")
+        private int hit;
+
+        @Schema(description = "팀블로그 게시글 스크랩 개수")
+        private int scrapCount;
+
+        @Schema(description = "팀블로그 게시글 파일 수 (파일 존재 여부 확인)")
+        private int totalFiles;
+
+        @Schema(description = "팀블로그 게시글 스크랩 여부")
+        private boolean existsScrap;
+
+        public static StudyPostItem of (StudyPost studyPost, int scrapCount, boolean existsScrap) {
+            int totalFiles = (studyPost.getFiles() != null) ? studyPost.getFiles().size() : 0;
+
+            return StudyPostItem.builder()
+                    .studyPostId(studyPost.getId())
+                    .writer(studyPost.getStudyMember().getMember().getNickname())
+                    .profileImg(studyPost.getStudyMember().getMember().getProfile().getImgUrl())
+                    .createdAt(studyPost.getCreatedAt())
+                    .updatedAt(studyPost.getUpdatedAt())
+                    .title(studyPost.getTitle())
+                    .hit(studyPost.getHit())
+                    .scrapCount(scrapCount)
+                    .totalFiles(totalFiles)
+                    .existsScrap(existsScrap)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class StudyPostListDto {
+        @Schema(description = "해당 스터디 아이디")
+        private Long studyId;
+
+        @Schema(description = "팀블로그 게시글 목록")
+        private List<StudyPostItem> items;
+
+        @Schema(description = "현재 페이지")
+        private int currentPage;
+
+        @Schema(description = "전체 페이지 수")
+        private int totalPages;
+
+        @Schema(description = "마지막 페이지 여부")
+        private boolean isLast;
+
+        public static StudyPostListDto of (Long studyId, Page<StudyPost> studyPosts, List<StudyPostItem> itemDtos) {
+            return StudyPostListDto.builder()
+                    .studyId(studyId)
+                    .items(itemDtos)
+                    .currentPage(studyPosts.getNumber() + 1)
+                    .totalPages(studyPosts.getTotalPages())
+                    .isLast(studyPosts.isLast())
                     .build();
         }
     }

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/StudyPostResponseDto.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/StudyPostResponseDto.java
@@ -37,9 +37,9 @@ public class StudyPostResponseDto {
         private List<FileDto> fileUrl;
         private int hit;
         private int scrapCount;
-        private Boolean isAuthor;
+        private boolean isAuthor;
 
-        public static StudyPostDto from(StudyPost studyPost, int scrapCount, Boolean isAuthor) {
+        public static StudyPostDto from(StudyPost studyPost, int scrapCount, boolean isAuthor) {
             List<FileDto> file = (studyPost.getFiles() != null) ? studyPost.getFiles().stream().map(FileDto::of).toList() : null;
 
             return StudyPostDto.builder()

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/entity/StudyPost.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/entity/StudyPost.java
@@ -3,6 +3,7 @@ package com.web.stard.domain.teamBlog.domain.entity;
 import com.web.stard.domain.post.domain.enums.PostType;
 import com.web.stard.domain.study.domain.entity.Study;
 import com.web.stard.domain.study.domain.entity.StudyMember;
+import com.web.stard.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-public class StudyPost {
+public class StudyPost extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "study_post_id", nullable = false)

--- a/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
@@ -10,4 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
     @EntityGraph(attributePaths = {"studyMember.member.profile"})
     Page<StudyPost> findByStudy(Study study, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"studyMember.member.profile"})
+    Page<StudyPost> findByStudyAndTitleContainingOrContentContaining(Study study, String keyword, String keyword1, Pageable pageable);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
@@ -1,5 +1,6 @@
 package com.web.stard.domain.teamBlog.repository;
 
+import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.study.domain.entity.Study;
 import com.web.stard.domain.teamBlog.domain.entity.StudyPost;
 import org.springframework.data.domain.Page;
@@ -13,4 +14,6 @@ public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
 
     @EntityGraph(attributePaths = {"studyMember.member.profile"})
     Page<StudyPost> findByStudyAndTitleContainingOrContentContaining(Study study, String keyword, String keyword1, Pageable pageable);
+
+    Page<StudyPost> findByStudyMember_MemberAndStudy(Member member, Study study, Pageable pageable);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/repository/StudyPostRepository.java
@@ -1,7 +1,13 @@
 package com.web.stard.domain.teamBlog.repository;
 
+import com.web.stard.domain.study.domain.entity.Study;
 import com.web.stard.domain.teamBlog.domain.entity.StudyPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
+    @EntityGraph(attributePaths = {"studyMember.member.profile"})
+    Page<StudyPost> findByStudy(Study study, Pageable pageable);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
@@ -3,6 +3,7 @@ package com.web.stard.domain.teamBlog.service;
 import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.post.domain.dto.request.PostRequestDto;
 import com.web.stard.domain.teamBlog.domain.dto.response.StudyPostResponseDto;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -21,4 +22,6 @@ public interface StudyPostService {
     StudyPostResponseDto.StudyPostListDto searchStudyPost(Long studyId, String keyword, Member member, int page);
 
     StudyPostResponseDto.StudyPostListDto getMemberStudyPostListByStudy(Long studyId, Member member, int page);
+
+    ResponseEntity<byte[]> downloadFile(Long studyId, Long studyPostFileId, Member member);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
@@ -19,4 +19,6 @@ public interface StudyPostService {
     StudyPostResponseDto.StudyPostListDto getStudyPostList(Long studyId, Member member, int page);
 
     StudyPostResponseDto.StudyPostListDto searchStudyPost(Long studyId, String keyword, Member member, int page);
+
+    StudyPostResponseDto.StudyPostListDto getMemberStudyPostListByStudy(Long studyId, Member member, int page);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
@@ -15,4 +15,6 @@ public interface StudyPostService {
     Long deleteStudyPost(Long studyId, Long studyPostId, Member member);
 
     StudyPostResponseDto.StudyPostDto getStudyPostDetail(Long studyId, Long studyPostId, Member member);
+
+    StudyPostResponseDto.StudyPostListDto getStudyPostList(Long studyId, Member member, int page);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/StudyPostService.java
@@ -17,4 +17,6 @@ public interface StudyPostService {
     StudyPostResponseDto.StudyPostDto getStudyPostDetail(Long studyId, Long studyPostId, Member member);
 
     StudyPostResponseDto.StudyPostListDto getStudyPostList(Long studyId, Member member, int page);
+
+    StudyPostResponseDto.StudyPostListDto searchStudyPost(Long studyId, String keyword, Member member, int page);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
@@ -292,6 +292,17 @@ public class StudyPostServiceImpl implements StudyPostService {
         return StudyPostResponseDto.StudyPostDto.from(studyPost, scrapCount, isAuthor, existsScrap);
     }
 
+    // 목록 조회 - 스크랩 수, 스크랩 여부 추가 메서드
+    private List<StudyPostResponseDto.StudyPostItem> findAllScrap(Page<StudyPost> studyPosts, Member member) {
+        return studyPosts.getContent().stream().map(studyPost -> {
+            int scrapCount = starScrapService.findStarScrapCount(studyPost.getId(), ActType.SCRAP, TableType.STUDYPOST);
+            boolean existsScrap = (starScrapService.existsStarScrap(member, studyPost.getId(), ActType.SCRAP, TableType.STUDYPOST) != null);
+
+            return StudyPostResponseDto.StudyPostItem.of(studyPost, scrapCount, existsScrap);
+        }).toList();
+    }
+
+
     /**
      * 스터디 - 커뮤니티 게시글 전체 조회
      *
@@ -314,13 +325,35 @@ public class StudyPostServiceImpl implements StudyPostService {
 
         Page<StudyPost> studyPosts = studyPostRepository.findByStudy(study, pageable);
 
-        List<StudyPostResponseDto.StudyPostItem> studyPostItems =
-                studyPosts.getContent().stream().map(studyPost -> {
-                    int scrapCount = starScrapService.findStarScrapCount(studyPost.getId(), ActType.SCRAP, TableType.STUDYPOST);
-                    boolean existsScrap = (starScrapService.existsStarScrap(member, studyPost.getId(), ActType.SCRAP, TableType.STUDYPOST) != null);
+        List<StudyPostResponseDto.StudyPostItem> studyPostItems = findAllScrap(studyPosts, member);
 
-                    return StudyPostResponseDto.StudyPostItem.of(studyPost, scrapCount, existsScrap);
-                }).toList();
+        return StudyPostResponseDto.StudyPostListDto.of(studyId, studyPosts, studyPostItems);
+    }
+
+    /**
+     * 스터디 - 커뮤니티 게시글 키워드 검색
+     *
+     * @param studyId 해당 study 고유 id
+     * @param keyword 조회할 키워드
+     * @param member 로그인 회원
+     * @param page 조회할 페이지 번호
+     *
+     * @return StudyPostListDto
+     *      studyId, StudyPostItem, currentPage 현재 페이지, totalPages 전체 페이지 수, isLast 마지막 페이지 여부
+     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public StudyPostResponseDto.StudyPostListDto searchStudyPost(Long studyId, String keyword, Member member, int page) {
+        Study study = studyService.findById(studyId);
+        studyService.isStudyMember(study, member);
+
+        Sort sort = Sort.by(new Sort.Order(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page-1, 10, sort);
+
+        Page<StudyPost> studyPosts = studyPostRepository.findByStudyAndTitleContainingOrContentContaining(study, keyword, keyword, pageable);
+
+        List<StudyPostResponseDto.StudyPostItem> studyPostItems = findAllScrap(studyPosts, member);
 
         return StudyPostResponseDto.StudyPostListDto.of(studyId, studyPosts, studyPostItems);
     }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
@@ -57,7 +57,7 @@ public class StudyPostServiceImpl implements StudyPostService {
     }
 
     // 작성자인지 확인
-    private Boolean isPostAuthor(StudyMember studyMember, StudyPost studyPost) {
+    private boolean isPostAuthor(StudyMember studyMember, StudyPost studyPost) {
         if (studyMember.getMember().getId() != studyPost.getStudyMember().getMember().getId()) {
             throw new CustomException(ErrorCode.INVALID_ACCESS);
         }
@@ -151,7 +151,7 @@ public class StudyPostServiceImpl implements StudyPostService {
         isEqualStudyPostStudyAndStudy(study, studyPost);
         StudyMember studyMember = studyMemberRepository.findByStudyAndMember(study, member)
                 .orElseThrow(() -> new CustomException(ErrorCode.STUDY_MEMBER_NOT_FOUND));
-        Boolean isAuthor = isPostAuthor(studyMember, studyPost);
+        boolean isAuthor = isPostAuthor(studyMember, studyPost);
 
         // 파일 최대, 최소 개수 확인
         int originFileCount = (studyPost.getFiles() != null) ? studyPost.getFiles().size() : 0;
@@ -275,7 +275,7 @@ public class StudyPostServiceImpl implements StudyPostService {
         StudyPost studyPost = findStudyPost(studyPostId);
         isEqualStudyPostStudyAndStudy(study, studyPost);
 
-        Boolean isAuthor = (member != null && studyPost.getStudyMember().getMember().getId() == member.getId());
+        boolean isAuthor = (studyPost.getStudyMember().getMember().getId() == member.getId());
 
         if (!isAuthor) {
             studyPost.incrementHitCount();

--- a/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/impl/StudyPostServiceImpl.java
@@ -312,7 +312,7 @@ public class StudyPostServiceImpl implements StudyPostService {
      *
      * @return StudyPostListDto
      *      studyId, StudyPostItem, currentPage 현재 페이지, totalPages 전체 페이지 수, isLast 마지막 페이지 여부
-     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수
+     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수, existsScrap 스크랩 여부
      */
     @Transactional(readOnly = true)
     @Override
@@ -340,7 +340,7 @@ public class StudyPostServiceImpl implements StudyPostService {
      *
      * @return StudyPostListDto
      *      studyId, StudyPostItem, currentPage 현재 페이지, totalPages 전체 페이지 수, isLast 마지막 페이지 여부
-     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수
+     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수, existsScrap 스크랩 여부
      */
     @Transactional(readOnly = true)
     @Override
@@ -352,6 +352,32 @@ public class StudyPostServiceImpl implements StudyPostService {
         Pageable pageable = PageRequest.of(page-1, 10, sort);
 
         Page<StudyPost> studyPosts = studyPostRepository.findByStudyAndTitleContainingOrContentContaining(study, keyword, keyword, pageable);
+
+        List<StudyPostResponseDto.StudyPostItem> studyPostItems = findAllScrap(studyPosts, member);
+
+        return StudyPostResponseDto.StudyPostListDto.of(studyId, studyPosts, studyPostItems);
+    }
+
+    /**
+     * 사용자 - 스터디 팀블로그 커뮤니티 작성한 게시글 스터디별 조회
+     *
+     * @param studyId 해당 study 고유 id
+     * @param member 로그인 회원
+     * @param page 조회할 페이지 번호
+     *
+     * @return StudyPostListDto
+     *      studyId, StudyPostItem, currentPage 현재 페이지, totalPages 전체 페이지 수, isLast 마지막 페이지 여부
+     *      StudyPostItem : studyPostId, writer 작성자, profileImg 프로필 이미지, title 제목, hit 조회수, scrapCount 스크랩 개수, totalFiles 파일 수, existsScrap 스크랩 여부
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public StudyPostResponseDto.StudyPostListDto getMemberStudyPostListByStudy(Long studyId, Member member, int page) {
+        Study study = studyService.findById(studyId);
+
+        Sort sort = Sort.by(new Sort.Order(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page-1, 10, sort);
+
+        Page<StudyPost> studyPosts = studyPostRepository.findByStudyMember_MemberAndStudy(member, study, pageable);
 
         List<StudyPostResponseDto.StudyPostItem> studyPostItems = findAllScrap(studyPosts, member);
 

--- a/src/main/java/com/web/stard/global/config/aws/S3Manager.java
+++ b/src/main/java/com/web/stard/global/config/aws/S3Manager.java
@@ -9,9 +9,11 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,5 +115,25 @@ public class S3Manager {
     // studyPost 디렉토리
     public String generateStudyPostKeyName(UUID uuid) {
         return amazonConfig.getStudyPostPath() + '/' + uuid.toString();
+    }
+
+    // 단일 파일 다운로드
+    public InputStream downloadFile(String fileUrl) {
+        try {
+            // 파일 URL에서 버킷 이름과 키를 추출
+            URL url = new URL(fileUrl);
+            String bucket = url.getHost().split("\\.")[0];
+            String key = url.getPath().substring(1);
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            return s3Client.getObject(getObjectRequest);
+        } catch (IOException e) {
+            log.error("error at S3Manager downloadFile: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.DOWNLOAD_FAILED);
+        }
     }
 }

--- a/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드에 실패했습니다."),
     DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제에 실패했습니다."),
     SIZE_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "파일 수와 키 이름 수가 일치하지 않습니다."),
+    DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 다운로드에 실패했습니다."),
 
 
     // Email
@@ -56,7 +57,7 @@ public enum ErrorCode {
     STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 팀블로그 커뮤니티 게시글입니다."),
     STUDY_POST_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 스터디 팀블로그 커뮤니티 요청입니다."),
     STUDY_POST_MAX_FILES_ALLOWED(HttpStatus.BAD_REQUEST, "최대 허용 파일 수를 초과했습니다."),
-    STUDY_POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제할 파일이 존재하지 않습니다."),
+    STUDY_POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
 
 
     // Reply


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #45 

## 📝 작업 내용
- [feat: 스터디 팀블로그 게시글 목록 조회](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/4261f3eb3469a0c4d8aa10bdd0fde11f319e41ce)
- [feat: 스터디 팀블로그 게시글 검색](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/89ee4c7d7f4e103e7ba41e5152905eb852fe646b)
- [feat: 마이페이지 스터디 팀블로그 작성 글 조회](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/f284ece07112a32597c5b84fb906cc28f94f528d)
- [feat: 스터디 팀블로그 게시글 파일 다운로드 구현](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/c551d841f8d46b966e573e2a0e86e21ea641464c)
## 📚 Reference


## 💬 리뷰 요구사항


## ❓ 질문사항
1. 검색 - 현재는 제목+내용 키워드 검색인데 제목/내용/제목+내용/작성자 나누는 게 나은지
2. 마이페이지 작성한 글 조회 - **스터디 별**로 조회하는 것만 있는데 전체 조회도 필요할지..? 만약에 전체 조회도 추가한다면 스터디 별로 묶어서 sort 할 것 같은데 그러면 굳이싶기는 해요. 어떻게 생각하시나요!

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
