### PR TITLE
feat: 스터디 팀블로그 - 평가 기능 구현

### DIFF
--- a/src/main/java/com/web/stard/domain/member/domain/entity/Profile.java
+++ b/src/main/java/com/web/stard/domain/member/domain/entity/Profile.java
@@ -30,4 +30,13 @@ public class Profile {
     public void deleteImageUrl() {
         this.imgUrl = null;
     }
+
+    public void updateCredibility(double starRating, int evaluatorCount) {
+        /* starRating = 평가에 반영할 평점
+           evaluatorCount = 기존 평가 인원수
+           (기존 평점 * 인원 + 매긴 점수) / (인원 + 1)
+           인원 + 1인 이유 : 기본 값 5점 */
+        double total = this.credibility * evaluatorCount + starRating;
+        this.credibility = total / (evaluatorCount + 1);
+    }
 }

--- a/src/main/java/com/web/stard/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/com/web/stard/domain/study/repository/StudyMemberRepository.java
@@ -16,4 +16,6 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
     List<StudyMember> findByMember(Member member);
 
     boolean existsByStudyAndMember(Study study, Member member);
+
+    List<StudyMember> findByStudy(Study study);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
@@ -2,6 +2,7 @@ package com.web.stard.domain.teamBlog.api;
 
 import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
+import com.web.stard.domain.teamBlog.domain.dto.response.EvaluationResponseDto;
 import com.web.stard.domain.teamBlog.service.EvaluationService;
 import com.web.stard.global.domain.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/studies/{studyId}/evaluations")
@@ -32,5 +35,14 @@ public class EvaluationController {
                                              @PathVariable(name = "evaluationId") Long evaluationId,
                                              @Valid @RequestBody EvaluationRequestDto.UpdateDto requestDto) {
         return ResponseEntity.ok(evaluationService.updateReason(studyId, evaluationId, member, requestDto));
+    }
+
+    @Operation(summary = "사용자의 스터디원 평가 전체 리스트")
+    @GetMapping
+    public ResponseEntity<List<EvaluationResponseDto.UserGivenEvaluationDto>> getMembersWithEvaluations (
+            @CurrentMember Member member,
+            @PathVariable(name = "studyId") Long studyId
+    ) {
+        return ResponseEntity.ok(evaluationService.getMembersWithEvaluations(studyId, member));
     }
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
@@ -1,0 +1,36 @@
+package com.web.stard.domain.teamBlog.api;
+
+import com.web.stard.domain.member.domain.entity.Member;
+import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
+import com.web.stard.domain.teamBlog.service.EvaluationService;
+import com.web.stard.global.domain.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/studies/{studyId}/evaluations")
+@RequiredArgsConstructor
+public class EvaluationController {
+
+    private final EvaluationService evaluationService;
+
+    @Operation(summary = "평가 등록", description = "평가 대상 회원 닉네임을 적어주세요.")
+    @PostMapping
+    public ResponseEntity<Long> createEvaluation(@CurrentMember Member member,
+                                                 @PathVariable(name = "studyId") Long studyId,
+                                                 @Valid @RequestBody EvaluationRequestDto.CreateDto requestDto) {
+        return ResponseEntity.ok(evaluationService.createEvaluation(studyId, member, requestDto));
+    }
+
+    @Operation(summary = "평가 사유 수정")
+    @PutMapping("/{evaluationId}")
+    public ResponseEntity<Long> updateReason(@CurrentMember Member member,
+                                             @PathVariable(name = "studyId") Long studyId,
+                                             @PathVariable(name = "evaluationId") Long evaluationId,
+                                             @Valid @RequestBody EvaluationRequestDto.UpdateDto requestDto) {
+        return ResponseEntity.ok(evaluationService.updateReason(studyId, evaluationId, member, requestDto));
+    }
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
@@ -37,12 +37,21 @@ public class EvaluationController {
         return ResponseEntity.ok(evaluationService.updateReason(studyId, evaluationId, member, requestDto));
     }
 
-    @Operation(summary = "사용자의 스터디원 평가 전체 리스트")
-    @GetMapping
-    public ResponseEntity<List<EvaluationResponseDto.UserGivenEvaluationDto>> getMembersWithEvaluations (
+    @Operation(summary = "사용자의 스터디원 평가 전체 리스트", description = "사용자가 평가할 수 있거나 평가한 스터디원 전체 리스트입니다.")
+    @GetMapping("/given")
+    public ResponseEntity<List<EvaluationResponseDto.EvaluationDto>> getStudyMembersWithEvaluations (
             @CurrentMember Member member,
             @PathVariable(name = "studyId") Long studyId
     ) {
-        return ResponseEntity.ok(evaluationService.getMembersWithEvaluations(studyId, member));
+        return ResponseEntity.ok(evaluationService.getStudyMembersWithEvaluations(studyId, member, "given"));
+    }
+
+    @Operation(summary = "사용자가 받은 스터디원 평가 전체 리스트", description = "다른 사용자로부터 받거나 받을 리스트입니다.")
+    @GetMapping("/received")
+    public ResponseEntity<List<EvaluationResponseDto.EvaluationDto>> getMemberReceivedEvaluations (
+            @CurrentMember Member member,
+            @PathVariable(name = "studyId") Long studyId
+    ) {
+        return ResponseEntity.ok(evaluationService.getStudyMembersWithEvaluations(studyId, member, "received"));
     }
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/dto/request/EvaluationRequestDto.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/dto/request/EvaluationRequestDto.java
@@ -1,0 +1,34 @@
+package com.web.stard.domain.teamBlog.domain.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+public class EvaluationRequestDto {
+
+    @Getter
+    public static class CreateDto {
+        @Schema(description = "평가할 회원 닉네임")
+        @NotBlank(message = "평가할 회원 닉네임을 입력하세요.")
+        private String target;
+
+        @Schema(example = "5.0", description = "별점")
+        @NotNull(message = "별점을 입력하세요.")
+        private double starRating;
+
+        @Schema(description = "별점 사유")
+        @NotBlank(message = "별점 사유를 입력하세요.")
+        @Size(max = 100, message = "최대 {max}자까지 입력 가능합니다.")
+        private String starReason;
+    }
+
+    @Getter
+    public static class UpdateDto {
+        @Schema(description = "별점 사유")
+        @NotBlank(message = "별점 사유를 입력하세요.")
+        @Size(max = 100, message = "최대 {max}자까지 입력 가능합니다.")
+        private String starReason;
+    }
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/EvaluationResponseDto.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/EvaluationResponseDto.java
@@ -11,12 +11,12 @@ public class EvaluationResponseDto {
 
     @Getter
     @Builder
-    public static class UserGivenEvaluationDto {
+    public static class EvaluationDto {
         @Schema(description = "해당 스터디 고유 id")
         private Long studyId;
 
-        @Schema(description = "대상 회원 닉네임")
-        private String target;
+        @Schema(description = "평가 대상 혹은 평가에 참여한 회원 닉네임")
+        private String nickname;
 
         @Schema(description = "평가 부여 여부")
         private boolean evaluationStatus;
@@ -29,10 +29,10 @@ public class EvaluationResponseDto {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private String starReason;
 
-        public static UserGivenEvaluationDto of (StudyMember target, Evaluation evaluation) {
-            return UserGivenEvaluationDto.builder()
-                    .studyId(target.getStudy().getId())
-                    .target(target.getMember().getNickname())
+        public static EvaluationDto of (StudyMember studyMember, Evaluation evaluation) {
+            return EvaluationDto.builder()
+                    .studyId(studyMember.getStudy().getId())
+                    .nickname(studyMember.getMember().getNickname())
                     .evaluationStatus(evaluation != null ? true : false)
                     .starRating(evaluation != null ? evaluation.getStarRating() : null)
                     .starReason(evaluation != null ? evaluation.getStarReason() : null)

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/EvaluationResponseDto.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/dto/response/EvaluationResponseDto.java
@@ -1,0 +1,42 @@
+package com.web.stard.domain.teamBlog.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.web.stard.domain.study.domain.entity.StudyMember;
+import com.web.stard.domain.teamBlog.domain.entity.Evaluation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class EvaluationResponseDto {
+
+    @Getter
+    @Builder
+    public static class UserGivenEvaluationDto {
+        @Schema(description = "해당 스터디 고유 id")
+        private Long studyId;
+
+        @Schema(description = "대상 회원 닉네임")
+        private String target;
+
+        @Schema(description = "평가 부여 여부")
+        private boolean evaluationStatus;
+
+        @Schema(description = "별점")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private Double starRating;
+
+        @Schema(description = "별점 사유")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String starReason;
+
+        public static UserGivenEvaluationDto of (StudyMember target, Evaluation evaluation) {
+            return UserGivenEvaluationDto.builder()
+                    .studyId(target.getStudy().getId())
+                    .target(target.getMember().getNickname())
+                    .evaluationStatus(evaluation != null ? true : false)
+                    .starRating(evaluation != null ? evaluation.getStarRating() : null)
+                    .starReason(evaluation != null ? evaluation.getStarReason() : null)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/domain/entity/Evaluation.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/domain/entity/Evaluation.java
@@ -1,0 +1,41 @@
+package com.web.stard.domain.teamBlog.domain.entity;
+
+import com.web.stard.domain.study.domain.entity.Study;
+import com.web.stard.domain.study.domain.entity.StudyMember;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class Evaluation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "evaluation_id", nullable = false)
+    private Long id;
+
+    @Column(name = "star_rating", nullable = false)
+    private double starRating; // 별점
+
+    @Column(name = "star_reason", nullable = false)
+    private String starReason; // 별점 사유
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_member_id", nullable = false)
+    private StudyMember studyMember; // 작성자 (평가한 회원)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    private StudyMember target; // 평가 대상 회원
+
+
+    public void updateStarReason(String starReason) {
+        this.starReason = starReason;
+    }
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/repository/EvaluationRepository.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/repository/EvaluationRepository.java
@@ -1,0 +1,11 @@
+package com.web.stard.domain.teamBlog.repository;
+
+import com.web.stard.domain.study.domain.entity.StudyMember;
+import com.web.stard.domain.teamBlog.domain.entity.Evaluation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
+    List<Evaluation> findByTarget(StudyMember studyMember);
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/repository/EvaluationRepository.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/repository/EvaluationRepository.java
@@ -5,7 +5,10 @@ import com.web.stard.domain.teamBlog.domain.entity.Evaluation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
     List<Evaluation> findByTarget(StudyMember studyMember);
+
+    Optional<Evaluation> findByStudyMemberAndTarget(StudyMember studyMember, StudyMember target);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
@@ -11,5 +11,5 @@ public interface EvaluationService {
 
     Long updateReason(Long studyId, Long evaluationId, Member member, EvaluationRequestDto.UpdateDto requestDto);
 
-    List<EvaluationResponseDto.UserGivenEvaluationDto> getMembersWithEvaluations(Long studyId, Member member);
+    List<EvaluationResponseDto.EvaluationDto> getStudyMembersWithEvaluations(Long studyId, Member member, String status);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
@@ -1,0 +1,9 @@
+package com.web.stard.domain.teamBlog.service;
+
+import com.web.stard.domain.member.domain.entity.Member;
+import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
+
+public interface EvaluationService {
+    Long createEvaluation(Long studyId, Member member, EvaluationRequestDto.CreateDto requestDto);
+    Long updateReason(Long studyId, Long evaluationId, Member member, EvaluationRequestDto.UpdateDto requestDto);
+}

--- a/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/EvaluationService.java
@@ -2,8 +2,14 @@ package com.web.stard.domain.teamBlog.service;
 
 import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
+import com.web.stard.domain.teamBlog.domain.dto.response.EvaluationResponseDto;
+
+import java.util.List;
 
 public interface EvaluationService {
     Long createEvaluation(Long studyId, Member member, EvaluationRequestDto.CreateDto requestDto);
+
     Long updateReason(Long studyId, Long evaluationId, Member member, EvaluationRequestDto.UpdateDto requestDto);
+
+    List<EvaluationResponseDto.UserGivenEvaluationDto> getMembersWithEvaluations(Long studyId, Member member);
 }

--- a/src/main/java/com/web/stard/domain/teamBlog/service/impl/EvaluationServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/service/impl/EvaluationServiceImpl.java
@@ -1,0 +1,101 @@
+package com.web.stard.domain.teamBlog.service.impl;
+
+import com.web.stard.domain.member.domain.entity.Member;
+import com.web.stard.domain.study.domain.entity.Study;
+import com.web.stard.domain.study.domain.entity.StudyMember;
+import com.web.stard.domain.study.domain.enums.ProgressType;
+import com.web.stard.domain.study.repository.StudyMemberRepository;
+import com.web.stard.domain.study.service.StudyService;
+import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
+import com.web.stard.domain.teamBlog.domain.entity.Evaluation;
+import com.web.stard.domain.teamBlog.repository.EvaluationRepository;
+import com.web.stard.domain.teamBlog.service.EvaluationService;
+import com.web.stard.global.exception.CustomException;
+import com.web.stard.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationServiceImpl implements EvaluationService {
+
+    private final EvaluationRepository evaluationRepository;
+    private final StudyService studyService;
+    private final StudyMemberRepository studyMemberRepository;
+
+
+    // 완료된 스터디인지 확인
+    public void isStudyCompleted(Study study) {
+        if (study.getProgressType() != ProgressType.COMPLETED) {
+            throw new CustomException(ErrorCode.STUDY_NOT_COMPLETED);
+        }
+    }
+
+    /**
+     * 스터디 - 팀원 평가 등록
+     *
+     * @param studyId 해당 study 고유 id
+     * @param member 로그인 회원
+     * @param requestDto target 평가 대상 닉네임, starRating 별점, starReason 별점 사유
+     *
+     */
+    @Transactional
+    @Override
+    public Long createEvaluation(Long studyId, Member member, EvaluationRequestDto.CreateDto requestDto) {
+        Study study = studyService.findById(studyId);
+        isStudyCompleted(study);
+
+        StudyMember studyMember = studyMemberRepository.findByStudyAndMember(study, member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_MEMBER_NOT_FOUND));
+        StudyMember target = studyMemberRepository.findByStudyAndMember_Nickname(study, requestDto.getTarget())
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_MEMBER_NOT_FOUND));
+
+        if (studyMember.getMember().getId() == target.getMember().getId()) { // 자기자신 평가 X
+            throw new CustomException(ErrorCode.STUDY_EVALUATION_BAD_REQUEST);
+        }
+
+        Evaluation evaluation = Evaluation.builder()
+                .starRating(requestDto.getStarRating())
+                .starReason(requestDto.getStarReason())
+                .study(study)
+                .studyMember(studyMember)
+                .target(target)
+                .build();
+
+        evaluationRepository.save(evaluation);
+
+        // 신뢰도 변경
+        List<Evaluation> evaluations = evaluationRepository.findByTarget(target);
+        int evaluatorCount = (evaluations != null) ? evaluations.size() : 0;
+        target.getMember().getProfile().updateCredibility(requestDto.getStarRating(), evaluatorCount);
+
+        return evaluation.getId();
+    }
+
+    /**
+     * 스터디 - 팀원 평가 별점 사유 수정
+     *
+     * @param studyId 해당 study 고유 id
+     * @param evaluationId 해당 평가 고유 id
+     * @param member 로그인 회원
+     * @param requestDto target 평가 대상 닉네임, starRating 별점, starReason 별점 사유
+     *
+     */
+    @Transactional
+    @Override
+    public Long updateReason(Long studyId, Long evaluationId, Member member, EvaluationRequestDto.UpdateDto requestDto) {
+        Evaluation evaluation = evaluationRepository.findById(evaluationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_EVALUATION_BAD_REQUEST));
+
+        if (evaluation.getStudyMember().getMember().getId() != member.getId()) {
+            throw new CustomException(ErrorCode.STUDY_EVALUATION_BAD_REQUEST);
+        }
+
+        evaluation.updateStarReason(requestDto.getStarReason());
+
+        return evaluation.getId();
+    }
+}

--- a/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
     STUDY_POST_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 스터디 팀블로그 커뮤니티 요청입니다."),
     STUDY_POST_MAX_FILES_ALLOWED(HttpStatus.BAD_REQUEST, "최대 허용 파일 수를 초과했습니다."),
     STUDY_POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
+    STUDY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "완료된 스터디가 아니므로 작업을 수행할 수 없습니다."),
+    STUDY_EVALUATION_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 스터디 팀블로그 평가 요청입니다."),
 
 
     // Reply

--- a/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/web/stard/global/exception/error/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     STUDY_POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
     STUDY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "완료된 스터디가 아니므로 작업을 수행할 수 없습니다."),
     STUDY_EVALUATION_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 스터디 팀블로그 평가 요청입니다."),
+    DUPLICATE_STUDY_EVALUATION_REQUEST(HttpStatus.CONFLICT, "이미 평가에 참여한 회원입니다."),
 
 
     // Reply


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #59 

## 📝 작업 내용
- [feat: 팀원 평가 등록, 수정 및 신뢰도 변경](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/10d809bb54d37817b1ed4133219603cfd7227096)
- [feat: 사용자의 스터디원 평가 내역 조회](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/6819bce9d3cfe36d9d928faa70aea8d7053e1f1c)
- [feat: 다른 사용자로부터의 평가 내역 조회](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/a03c548a102953d9a6fed8d13eb099422eb64cc2)

## 📚 Reference

## 📍 프론트 전달 사항
- 별점 수정 X, 사유만 수정 가능 O / 삭제 불가능
- 평가 여부와 상관없이 모든 스터디원 리스트를 전달합니다! <br> 평가 여부와, true일 시 별점, 사유도 함께 전달하도록 구현했습니다. 다른 방식이 편하면 말씀해주세요,,

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
