### PR TITLE
refactor: responseDto에 createdAt 필드 추가, JVM 타임존 설정

### DIFF
--- a/src/main/java/com/web/stard/StardApplication.java
+++ b/src/main/java/com/web/stard/StardApplication.java
@@ -1,9 +1,12 @@
 package com.web.stard;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -12,6 +15,11 @@ public class StardApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(StardApplication.class, args);
+	}
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 
 }

--- a/src/main/java/com/web/stard/domain/post/domain/dto/response/PostResponseDto.java
+++ b/src/main/java/com/web/stard/domain/post/domain/dto/response/PostResponseDto.java
@@ -5,6 +5,7 @@ import com.web.stard.domain.post.domain.entity.Post;
 import com.web.stard.domain.post.domain.enums.PostType;
 import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.member.domain.enums.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -17,21 +18,47 @@ public class PostResponseDto {
     @Getter
     @Builder
     public static class PostDto {
+        @Schema(description = "게시글 아이디")
         private Long postId;
+
+        @Schema(description = "게시글 제목")
         private String title;
+
+        @Schema(description = "게시글 내용")
         private String content;
+
+        @Schema(description = "커뮤니티 글 카테고리")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private String category;
+
+        @Schema(description = "조회수")
         private int hit;
+
+        @Schema(description = "게시글 타입")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private PostType postType;
+
+        @Schema(description = "작성자 여부")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private Boolean isAuthor;
+
+        @Schema(description = "회원 닉네임")
         private String writer;
+
+        @Schema(description = "회원 프로필 url")
         private String profileImg;
+
+        @Schema(description = "게시글 생성 일시")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "게시글 수정 일시")
         private LocalDateTime updatedAt;
+
+        @Schema(description = "공감수")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private Integer starCount;
+
+        @Schema(description = "공감(스타) 존재 여부")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private Boolean existsStar;
 
@@ -59,6 +86,7 @@ public class PostResponseDto {
                     .isAuthor(isAuthor)
                     .writer(writerName)
                     .profileImg(profileImage)
+                    .createdAt(post.getCreatedAt())
                     .updatedAt(post.getUpdatedAt())
                     .starCount(starCount)
                     .build();

--- a/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
+++ b/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
@@ -24,10 +24,10 @@ public class ReplyResponseDto {
         @Schema(description = "작성자 여부")
         private boolean isAuthor;
 
-        @Schema(description = "회원 닉네임")
+        @Schema(description = "작성자 닉네임")
         private String writer;
 
-        @Schema(description = "회원 프로필 url")
+        @Schema(description = "작성자 프로필 url")
         private String profileImg;
 
         @Schema(description = "댓글 작성 일시")

--- a/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
+++ b/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
@@ -2,6 +2,7 @@ package com.web.stard.domain.reply.domain.dto.response;
 
 import com.web.stard.domain.reply.domain.entity.Reply;
 import com.web.stard.domain.member.domain.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -14,11 +15,25 @@ public class ReplyResponseDto {
     @Getter
     @Builder
     public static class ReplyDto {
+        @Schema(description = "댓글 아이디")
         private Long replyId;
+
+        @Schema(description = "댓글 내용")
         private String content;
+
+        @Schema(description = "작성자 여부")
         private boolean isAuthor;
+
+        @Schema(description = "작성자 닉네임")
         private String writer;
+
+        @Schema(description = "작성자 프로필 url")
         private String profileImg;
+
+        @Schema(description = "댓글 작성 일시")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "댓글 수정 일시")
         private LocalDateTime updatedAt;
 
         public static ReplyDto from(Reply reply, Member member, boolean isAuthor) {
@@ -28,6 +43,7 @@ public class ReplyResponseDto {
                     .isAuthor(isAuthor)
                     .writer(member.getNickname())
                     .profileImg(member.getProfile().getImgUrl())
+                    .createdAt(reply.getCreatedAt())
                     .updatedAt(reply.getUpdatedAt())
                     .build();
         }

--- a/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
+++ b/src/main/java/com/web/stard/domain/reply/domain/dto/response/ReplyResponseDto.java
@@ -24,10 +24,10 @@ public class ReplyResponseDto {
         @Schema(description = "작성자 여부")
         private boolean isAuthor;
 
-        @Schema(description = "작성자 닉네임")
+        @Schema(description = "회원 닉네임")
         private String writer;
 
-        @Schema(description = "작성자 프로필 url")
+        @Schema(description = "회원 프로필 url")
         private String profileImg;
 
         @Schema(description = "댓글 작성 일시")


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #

## 📝 작업 내용
-   [refactor: 댓글 responseDto에 생성일시, 스키마 정보 추가](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/a39a64b7f1f842cb33cc142be6a9f2108c2ca553)
- [refactor: post responseDto에 생성일시, 스키마 정보 추가](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/1bb2df2a2d9ce77df86a81b5d0b5f0e077b5d36b)
- [chore: JVM 기본 타임존 설정](https://github.com/Hanium2023-WeB/starD-backend-refactoring/commit/1155d5a433f68360296cd0a0133a851d412fb9de)
## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
