### PR TITLE
feat: JWT 토큰 재발급 API 구현 / 로그인, 로그아웃 시 Refresh Token 쿠키 추가 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/web/stard/domain/member/api/AuthController.java
+++ b/src/main/java/com/web/stard/domain/member/api/AuthController.java
@@ -63,8 +63,8 @@ public class AuthController {
 
     @PostMapping("/reissue")
     @Operation(summary = "JWT 토큰 재발급")
-    public ResponseEntity<TokenInfo> reissue(HttpServletRequest request) {
-        return ResponseEntity.ok(authService.reissue(request));
+    public ResponseEntity<TokenInfo> reissue(HttpServletResponse response, HttpServletRequest request) {
+        return ResponseEntity.ok(authService.reissue(response, request));
     }
 
     @PostMapping("/auth-codes")
@@ -83,8 +83,9 @@ public class AuthController {
 
     @PostMapping("/sign-out")
     @Operation(summary = "로그아웃")
-    public ResponseEntity<Boolean> validAuthCode(@CurrentMember Member member, HttpServletRequest request) {
-        authService.signOut(member, headerUtils.resolveToken(request));
+    public ResponseEntity<Boolean> signOut(@CurrentMember Member member, HttpServletRequest request,
+                                                 HttpServletResponse response) {
+        authService.signOut(member, headerUtils.resolveToken(request), response);
         return ResponseEntity.ok().body(true);
     }
 

--- a/src/main/java/com/web/stard/domain/member/api/AuthController.java
+++ b/src/main/java/com/web/stard/domain/member/api/AuthController.java
@@ -9,6 +9,7 @@ import com.web.stard.global.dto.TokenInfo;
 import com.web.stard.global.utils.HeaderUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -24,7 +25,6 @@ public class AuthController {
     private final HeaderUtils headerUtils;
     private final AuthService authService;
 
-    // 회원가입
     @Operation(summary = "회원가입")
     @PostMapping(value = "/join", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MemberResponseDto.SignupResultDto> signUp(@RequestPart(value = "file", required = false) MultipartFile file,
@@ -53,12 +53,18 @@ public class AuthController {
         MemberResponseDto.AdditionalInfoResultDto result = authService.saveAdditionalInfo(requestDto);
         return ResponseEntity.ok(result);
     }
-    
-    // 로그인
+
     @PostMapping("/sign-in")
     @Operation(summary = "로그인")
-    public ResponseEntity<TokenInfo> signIn(@Valid @RequestBody MemberRequestDto.SignInDto request) {
-        return ResponseEntity.ok(authService.signIn(request));
+    public ResponseEntity<TokenInfo> signIn(@Valid @RequestBody MemberRequestDto.SignInDto request,
+                                            HttpServletResponse response) {
+        return ResponseEntity.ok(authService.signIn(request, response));
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "JWT 토큰 재발급")
+    public ResponseEntity<TokenInfo> reissue(HttpServletRequest request) {
+        return ResponseEntity.ok(authService.reissue(request));
     }
 
     @PostMapping("/auth-codes")

--- a/src/main/java/com/web/stard/domain/member/service/AuthService.java
+++ b/src/main/java/com/web/stard/domain/member/service/AuthService.java
@@ -4,6 +4,8 @@ import com.web.stard.domain.member.domain.entity.Member;
 import com.web.stard.domain.member.domain.dto.request.MemberRequestDto;
 import com.web.stard.domain.member.domain.dto.response.MemberResponseDto;
 import com.web.stard.global.dto.TokenInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthService {
@@ -15,11 +17,13 @@ public interface AuthService {
 
     MemberResponseDto.AdditionalInfoResultDto saveAdditionalInfo(MemberRequestDto.AdditionalInfoRequestDto requestDto);
 
-    TokenInfo signIn(MemberRequestDto.SignInDto request);
+    TokenInfo signIn(MemberRequestDto.SignInDto request, HttpServletResponse response);
 
     void sendAuthCode(String email) throws Exception;
 
     void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception;
 
     void signOut(Member member, String token);
+
+    TokenInfo reissue(HttpServletRequest request);
 }

--- a/src/main/java/com/web/stard/domain/member/service/AuthService.java
+++ b/src/main/java/com/web/stard/domain/member/service/AuthService.java
@@ -23,7 +23,7 @@ public interface AuthService {
 
     void validAuthCode(MemberRequestDto.AuthCodeRequestDto request) throws Exception;
 
-    void signOut(Member member, String token);
+    void signOut(Member member, String token, HttpServletResponse response);
 
-    TokenInfo reissue(HttpServletRequest request);
+    TokenInfo reissue(HttpServletResponse response, HttpServletRequest request);
 }

--- a/src/main/java/com/web/stard/domain/member/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/service/impl/AuthServiceImpl.java
@@ -14,8 +14,11 @@ import com.web.stard.global.config.security.JwtTokenProvider;
 import com.web.stard.global.dto.TokenInfo;
 import com.web.stard.global.exception.CustomException;
 import com.web.stard.global.exception.error.ErrorCode;
+import com.web.stard.global.utils.CookieUtils;
 import com.web.stard.global.utils.EmailUtils;
 import com.web.stard.global.utils.RedisUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -39,6 +42,7 @@ public class AuthServiceImpl implements AuthService {
     private final S3Manager s3Manager;
     private final RedisUtils redisUtils;
     private final EmailUtils emailUtils;
+    private final CookieUtils cookieUtils;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManager authenticationManager;
 
@@ -160,12 +164,13 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public TokenInfo signIn(MemberRequestDto.SignInDto request) {
+    public TokenInfo signIn(MemberRequestDto.SignInDto request, HttpServletResponse response) {
         try {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.email(), request.password());
             Authentication authentication = authenticationManager.authenticate(authenticationToken);
             TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
             redisUtils.setData(request.email(), tokenInfo.getRefreshToken(), tokenInfo.getRefreshTokenExpirationTime());
+            cookieUtils.generateRefreshTokenCookie(response, tokenInfo);
             return tokenInfo;
         } catch (BadCredentialsException e) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
@@ -212,6 +217,23 @@ public class AuthServiceImpl implements AuthService {
         } catch (Exception e) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    @Override
+    public TokenInfo reissue(HttpServletRequest request) {
+        String refreshToken = cookieUtils.getCookie(request);
+        jwtTokenProvider.validateToken(refreshToken);
+
+        String username = jwtTokenProvider.parseClaims(refreshToken).getSubject();
+        if (redisUtils.getData(username) != null) {
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+
+        return tokenInfo;
     }
 
 }

--- a/src/main/java/com/web/stard/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/member/service/impl/MemberServiceImpl.java
@@ -202,4 +202,48 @@ public class MemberServiceImpl implements MemberService {
         unknownMemberService.createUnknownMemberIfNotExist();
     }
 
+//    @Transactional
+//    public void sendEmailResetPw(MemberRequestDto.EmailRequestDto request) throws MessagingException {
+//
+//        Member member = memberService.findByEmail(emailDto.getEmail());
+//
+//        String pwResetToken = UUID.randomUUID().toString();
+//
+//        boolean isExist = true;
+//
+//        while(isExist){
+//
+//            String existEmail = redisUtil.getData(RESET_PW_PREFIX + pwResetToken);
+//            if (existEmail == null)
+//                break;
+//            else
+//                pwResetToken = UUID.randomUUID().toString();
+//        }
+//
+//        String pwResetUrl = baseUrl + "/reset-password?token=" + pwResetToken;
+//
+//        MimeMessage message = emailSender.createMimeMessage();
+//        message.addRecipients(MimeMessage.RecipientType.TO, emailDto.getEmail());
+//        message.setSubject(RESET_PW_SUBJECT);
+//
+//        String messageContent = "<h2>비밀번호 재설정 안내 </h2> <br>" +
+//                "<p>안녕하세요. " + member.getId() +" 님</p>" +
+//                "<p>본 메일은 비밀번호 재설정을 위해 StarD에서 발송하는 메일입니다. 12시간 이내에 " +
+//                "링크를 클릭하여 비밀번호 재설정을 완료해주세요.</p>" +
+//                "<a href=\"" + pwResetUrl + "\">비밀번호 재설정</a>";
+//
+//        message.setText(messageContent, "UTF-8", "html");
+//        String sender = adminAccount + "@naver.com";
+//        message.setFrom(new InternetAddress(sender));
+//
+//        try {
+//            emailSender.send(message);
+//            redisUtil.setData(RESET_PW_PREFIX + pwResetToken, emailDto.getEmail(), RESET_PW_TOKEN_EXPIRE_TIME);
+//        } catch (MailException e) {
+//            e.printStackTrace();
+//            log.debug("MailService.sendEmail exception occur toEmail: {}", emailDto.getEmail());
+//            throw new IllegalArgumentException();
+//        }
+//    }
+
 }

--- a/src/main/java/com/web/stard/global/config/WebConfig.java
+++ b/src/main/java/com/web/stard/global/config/WebConfig.java
@@ -10,7 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:3000",
+                        "https://star-d-frontend.vercel.app")
                 .allowedHeaders("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowCredentials(true);

--- a/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
             "/members/auth/join", "/members/auth/check-email", "/members/auth/check-nickname",
-            "/members/auth/join/additional-info", "/members/auth/sign-in",
+            "/members/auth/join/additional-info", "/members/auth/sign-in", "/members/auth/reissue",
             "/members/auth/auth-codes", "/members/auth/auth-codes/verify",
             "/studies/search"
     };

--- a/src/main/java/com/web/stard/global/utils/CookieUtils.java
+++ b/src/main/java/com/web/stard/global/utils/CookieUtils.java
@@ -7,9 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 @Component
 public class CookieUtils {
 
@@ -30,7 +27,7 @@ public class CookieUtils {
 
     public HttpServletResponse generateRefreshTokenCookie(HttpServletResponse response, TokenInfo tokenInfo) {
         ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, tokenInfo.getRefreshToken())
-                .maxAge(tokenInfo.getRefreshTokenExpirationTime())
+                .maxAge(604800)
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)
@@ -40,37 +37,13 @@ public class CookieUtils {
         return response;
     }
 
-    public HttpServletResponse updateCookie(HttpServletRequest request, HttpServletResponse response, TokenInfo tokenInfo) {
-        Cookie[] cookies = request.getCookies();
-
-        if (cookies != null) {
-            Arrays.stream(cookies)
-                    .filter(cookie -> cookie.getName().equals("refreshToken"))
-                    .findFirst()
-                    .ifPresent(cookie -> {
-                        ResponseCookie expiredCookie = ResponseCookie.from(cookie.getName(), null)
-                                .maxAge(0)
-                                .path("/")
-                                .sameSite("None")
-                                .httpOnly(true)
-                                .secure(true)
-                                .build();
-                        response.addHeader("Set-Cookie", expiredCookie.toString());
-                    });
-        }
-
-        ResponseCookie newCookie = ResponseCookie.from(COOKIE_NAME, tokenInfo.getRefreshToken())
-                .maxAge(tokenInfo.getRefreshTokenExpirationTime())
-                .path("/")
-                .sameSite("None")
-                .httpOnly(true)
-                .secure(true)
+    public HttpServletResponse deleteRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, refreshToken)
+                .maxAge(0)
                 .build();
-        response.addHeader("Set-Cookie", newCookie.toString());
-
+        response.addHeader("Set-Cookie", cookie.toString());
         return response;
     }
-
 
 
 }

--- a/src/main/java/com/web/stard/global/utils/CookieUtils.java
+++ b/src/main/java/com/web/stard/global/utils/CookieUtils.java
@@ -1,0 +1,76 @@
+package com.web.stard.global.utils;
+
+import com.web.stard.global.dto.TokenInfo;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class CookieUtils {
+
+    private final String COOKIE_NAME = "refreshToken";
+
+    public String getCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(COOKIE_NAME)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public HttpServletResponse generateRefreshTokenCookie(HttpServletResponse response, TokenInfo tokenInfo) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, tokenInfo.getRefreshToken())
+                .maxAge(tokenInfo.getRefreshTokenExpirationTime())
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+                .secure(true)
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+        return response;
+    }
+
+    public HttpServletResponse updateCookie(HttpServletRequest request, HttpServletResponse response, TokenInfo tokenInfo) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            Arrays.stream(cookies)
+                    .filter(cookie -> cookie.getName().equals("refreshToken"))
+                    .findFirst()
+                    .ifPresent(cookie -> {
+                        ResponseCookie expiredCookie = ResponseCookie.from(cookie.getName(), null)
+                                .maxAge(0)
+                                .path("/")
+                                .sameSite("None")
+                                .httpOnly(true)
+                                .secure(true)
+                                .build();
+                        response.addHeader("Set-Cookie", expiredCookie.toString());
+                    });
+        }
+
+        ResponseCookie newCookie = ResponseCookie.from(COOKIE_NAME, tokenInfo.getRefreshToken())
+                .maxAge(tokenInfo.getRefreshTokenExpirationTime())
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+                .secure(true)
+                .build();
+        response.addHeader("Set-Cookie", newCookie.toString());
+
+        return response;
+    }
+
+
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #25 

## 📝 작업 내용
- JWT 토큰 재발급 API 구현
- 로그인 시 Refresh Token 쿠키 추가
- 로그아웃 시 Refresh Token 쿠키 삭제

## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
