### PR TITLE
fix: 스터디 모집 게시글 상세 조회 API 인증 없이 접근하도록 수정

### DIFF
--- a/src/main/java/com/web/stard/domain/reply/service/impl/ReplyServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/reply/service/impl/ReplyServiceImpl.java
@@ -87,7 +87,7 @@ public class ReplyServiceImpl implements ReplyService {
             Study study = studyRepository.findById(targetId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
 
             if (!writer.equals(study.getMember())) {
-                List<Member> members = List.of(writer);
+                List<Member> members = List.of(study.getMember());
                 notificationService.sendNotis(members,
                         new NotificationRequest.SendRequestDto("댓글이 달렸습니다.", reply.getContent(), NotificationType.REPLY
                                 , study.getId()));

--- a/src/main/java/com/web/stard/domain/study/domain/dto/response/StudyResponseDto.java
+++ b/src/main/java/com/web/stard/domain/study/domain/dto/response/StudyResponseDto.java
@@ -206,7 +206,7 @@ public class StudyResponseDto {
                     .recruitmentDeadline(study.getRecruitmentDeadline())
                     .city(study.getCity())
                     .district(study.getDistrict())
-                    .isAuthor(study.getMember().getId().equals(member.getId()))
+                    .isAuthor((member != null) ? study.getMember().getId().equals(member.getId()) : false)
                     .field(study.getField().getDescription())
                     .existsScrap(existsScrap)
                     .build();

--- a/src/main/java/com/web/stard/domain/study/service/impl/StudyServiceImpl.java
+++ b/src/main/java/com/web/stard/domain/study/service/impl/StudyServiceImpl.java
@@ -99,10 +99,12 @@ public class StudyServiceImpl implements StudyService {
     @Override
     @Transactional
     public StudyResponseDto.DetailInfo findStudyDetailInfo(Long studyId, Member member) {
-        member = memberRepository.findById(member.getId()).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
         int scrapCount = starScrapService.findStarScrapCount(study.getId(), ActType.SCRAP, TableType.STUDY);
         studyRepository.incrementHitById(studyId);
+        if (!Objects.isNull(member)) {
+            member = memberRepository.findById(member.getId()).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        }
         boolean isScrapped = (starScrapService.existsStarScrap(member, study.getId(), ActType.SCRAP, TableType.STUDY) != null);
         return StudyResponseDto.DetailInfo.toDto(study, member, scrapCount, isScrapped);
     }

--- a/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/web/stard/global/config/security/SecurityConfig.java
@@ -33,14 +33,13 @@ public class SecurityConfig {
     private final HeaderUtils headerUtils;
     private final RedisUtils redisUtils;
 
-    private static final String[] PERMIT_ALL_PATTERNS = new String[] {
+    private static final String[] PERMIT_ALL_PATTERNS = new String[]{
             "/members/auth/join", "/members/auth/check-email", "/members/auth/check-nickname",
             "/members/auth/join/additional-info", "/members/auth/sign-in", "/members/auth/reissue",
             "/members/auth/auth-codes", "/members/auth/auth-codes/verify",
             "/members/auth/find-password", "/members/reset-password",
             "/members/auth/valid-password-reset-token", "/gs-guide-websocket",
-
-            "/studies/hot-tag", "/studies/search", "/studies/hot-field"
+            "/studies/*"
     };
 
     @Bean


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #91 

## 📝 작업 내용
-   스터디 모집 게시글 상세 조회 API 인증 없이 접근하도록 수정
## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
