### PR TITLE
feat: 스웨거 에러 응답값 커스텀 어노테이션 구현

### DIFF
--- a/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
+++ b/src/main/java/com/web/stard/domain/teamBlog/api/EvaluationController.java
@@ -5,6 +5,9 @@ import com.web.stard.domain.teamBlog.domain.dto.request.EvaluationRequestDto;
 import com.web.stard.domain.teamBlog.domain.dto.response.EvaluationResponseDto;
 import com.web.stard.domain.teamBlog.service.EvaluationService;
 import com.web.stard.global.domain.CurrentMember;
+import com.web.stard.global.exception.ApiErrorCodeExample;
+import com.web.stard.global.exception.ApiErrorCodeExamples;
+import com.web.stard.global.exception.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,6 +26,12 @@ public class EvaluationController {
     private final EvaluationService evaluationService;
 
     @Operation(summary = "평가 등록", description = "평가 대상 회원 닉네임을 적어주세요.")
+    @ApiErrorCodeExamples({
+            ErrorCode.STUDY_NOT_FOUND,
+            ErrorCode.STUDY_NOT_COMPLETED,
+            ErrorCode.STUDY_EVALUATION_BAD_REQUEST,
+            ErrorCode.DUPLICATE_STUDY_EVALUATION_REQUEST
+    })
     @PostMapping
     public ResponseEntity<Long> createEvaluation(@CurrentMember Member member,
                                                  @PathVariable(name = "studyId") Long studyId,
@@ -31,6 +40,7 @@ public class EvaluationController {
     }
 
     @Operation(summary = "평가 사유 수정")
+    @ApiErrorCodeExample(ErrorCode.STUDY_EVALUATION_BAD_REQUEST)
     @PutMapping("/{evaluationId}")
     public ResponseEntity<Long> updateReason(@CurrentMember Member member,
                                              @PathVariable(name = "studyId") Long studyId,
@@ -40,6 +50,11 @@ public class EvaluationController {
     }
 
     @Operation(summary = "사용자의 스터디원 평가 전체 리스트", description = "사용자가 평가할 수 있거나 평가한 스터디원 전체 리스트입니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.STUDY_NOT_FOUND,
+            ErrorCode.STUDY_NOT_COMPLETED,
+            ErrorCode.STUDY_MEMBER_NOT_FOUND
+    })
     @GetMapping("/given")
     public ResponseEntity<List<EvaluationResponseDto.EvaluationDto>> getStudyMembersWithEvaluations (
             @CurrentMember Member member,
@@ -49,6 +64,11 @@ public class EvaluationController {
     }
 
     @Operation(summary = "사용자가 받은 스터디원 평가 전체 리스트", description = "다른 사용자로부터 받거나 받을 리스트입니다.")
+    @ApiErrorCodeExamples({
+            ErrorCode.STUDY_NOT_FOUND,
+            ErrorCode.STUDY_NOT_COMPLETED,
+            ErrorCode.STUDY_MEMBER_NOT_FOUND
+    })
     @GetMapping("/received")
     public ResponseEntity<List<EvaluationResponseDto.EvaluationDto>> getMemberReceivedEvaluations (
             @CurrentMember Member member,

--- a/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
@@ -95,6 +95,7 @@ public class SwaggerConfig {
                             .holder(getSwaggerExample(errorCode))
                             .code(errorCode.getHttpStatus().value())
                             .name(errorCode.name())
+                            .description(errorCode.getHttpStatus().getReasonPhrase())
                             .build()
                 )
                 .collect(Collectors.groupingBy(ExampleHolder::getCode));
@@ -111,6 +112,7 @@ public class SwaggerConfig {
                 .holder(getSwaggerExample(errorCode))
                 .name(errorCode.name())
                 .code(errorCode.getHttpStatus().value())
+                .description(errorCode.getHttpStatus().getReasonPhrase())
                 .build();
 
         addExamplesToResponses(responses, exampleHolder);
@@ -123,17 +125,6 @@ public class SwaggerConfig {
         example.setValue(errorResponseDto);
 
         return example;
-    }
-
-    private String getDescription(int status) {
-        return switch (status) {
-            case 400 -> "BAD_REQUEST";
-            case 401 -> "UNAUTHORIZED";
-            case 403 -> "FORBIDDEN";
-            case 404 -> "NOT_FOUND";
-            case 409 -> "CONFLICT";
-            default -> "INTERNAL_SERVER_ERROR";
-        };
     }
 
     private void addExamplesToResponses(ApiResponses responses,
@@ -150,8 +141,11 @@ public class SwaggerConfig {
                                     exampleHolder.getHolder()
                             )
                     );
+
+                    if (!v.isEmpty()) {
+                        apiResponse.setDescription(v.get(0).getDescription());
+                    }
                     content.addMediaType("application/json", mediaType);
-                    apiResponse.setDescription(getDescription(status));
                     apiResponse.setContent(content);
                     responses.addApiResponse(String.valueOf(status), apiResponse);
                 }
@@ -165,7 +159,7 @@ public class SwaggerConfig {
 
         mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
         content.addMediaType("application/json", mediaType);
-        apiResponse.setDescription(getDescription(exampleHolder.getCode()));
+        apiResponse.setDescription(exampleHolder.getDescription());
         apiResponse.content(content);
         responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
     }

--- a/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/web/stard/global/config/swagger/SwaggerConfig.java
@@ -1,17 +1,33 @@
 package com.web.stard.global.config.swagger;
 
+import com.web.stard.global.dto.ErrorResponseDto;
+import com.web.stard.global.exception.ApiErrorCodeExample;
+import com.web.stard.global.exception.ApiErrorCodeExamples;
+import com.web.stard.global.exception.ExampleHolder;
+import com.web.stard.global.exception.error.ErrorCode;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.method.HandlerMethod;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
@@ -41,6 +57,117 @@ public class SwaggerConfig {
         var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
         supportedMediaTypes.add(new MediaType("application", "octet-stream"));
         converter.setSupportedMediaTypes(supportedMediaTypes);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(
+                    ApiErrorCodeExamples.class);
+
+            // @ApiErrorCodeExamples 어노테이션이 붙어있다면
+            if (apiErrorCodeExamples != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExamples.value());
+            }
+            else {
+                ApiErrorCodeExample apiErrorCodeExample = handlerMethod.getMethodAnnotation(
+                        ApiErrorCodeExample.class);
+
+                // @ApiErrorCodeExamples 어노테이션이 붙어있지 않고
+                // @ApiErrorCodeExample 어노테이션이 붙어있다면
+                if (apiErrorCodeExample != null) {
+                    generateErrorCodeResponseExample(operation, apiErrorCodeExample.value());
+                }
+            }
+
+            return operation;
+        };
+    }
+
+    // 여러 개의 에러 응답값 추가
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode[] errorCodes) {
+        ApiResponses responses = operation.getResponses();
+
+        // ExampleHolder(에러 응답값) 객체를 만들고 에러 코드별로 그룹화
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorCodes)
+                .map(
+                    errorCode -> ExampleHolder.builder()
+                            .holder(getSwaggerExample(errorCode))
+                            .code(errorCode.getHttpStatus().value())
+                            .name(errorCode.name())
+                            .build()
+                )
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        // ExampleHolders를 ApiResponses에 추가
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    // 단일 에러 응답값 추가
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode errorCode) {
+        ApiResponses responses = operation.getResponses();
+
+        ExampleHolder exampleHolder = ExampleHolder.builder()
+                .holder(getSwaggerExample(errorCode))
+                .name(errorCode.name())
+                .code(errorCode.getHttpStatus().value())
+                .build();
+
+        addExamplesToResponses(responses, exampleHolder);
+    }
+
+    // ErrorResponseDto 형태의 예시 객체 생성
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.of(errorCode);
+        Example example = new Example();
+        example.setValue(errorResponseDto);
+
+        return example;
+    }
+
+    private String getDescription(int status) {
+        return switch (status) {
+            case 400 -> "BAD_REQUEST";
+            case 401 -> "UNAUTHORIZED";
+            case 403 -> "FORBIDDEN";
+            case 404 -> "NOT_FOUND";
+            case 409 -> "CONFLICT";
+            default -> "INTERNAL_SERVER_ERROR";
+        };
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    io.swagger.v3.oas.models.media.MediaType mediaType = new io.swagger.v3.oas.models.media.MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(),
+                                    exampleHolder.getHolder()
+                            )
+                    );
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription(getDescription(status));
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(String.valueOf(status), apiResponse);
+                }
+        );
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        Content content = new Content();
+        io.swagger.v3.oas.models.media.MediaType mediaType = new io.swagger.v3.oas.models.media.MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+
+        mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
+        content.addMediaType("application/json", mediaType);
+        apiResponse.setDescription(getDescription(exampleHolder.getCode()));
+        apiResponse.content(content);
+        responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
     }
 
 }

--- a/src/main/java/com/web/stard/global/dto/ErrorResponseDto.java
+++ b/src/main/java/com/web/stard/global/dto/ErrorResponseDto.java
@@ -1,0 +1,18 @@
+package com.web.stard.global.dto;
+
+import com.web.stard.global.exception.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponseDto {
+
+    private final int status;
+    private final String errorCode;
+    private final String message;
+
+    public static ErrorResponseDto of (ErrorCode errorCode) {
+        return new ErrorResponseDto(errorCode.getHttpStatus().value(), errorCode.toString(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/web/stard/global/exception/ApiErrorCodeExample.java
+++ b/src/main/java/com/web/stard/global/exception/ApiErrorCodeExample.java
@@ -1,0 +1,16 @@
+package com.web.stard.global.exception;
+
+import com.web.stard.global.exception.error.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorCode value();
+
+}

--- a/src/main/java/com/web/stard/global/exception/ApiErrorCodeExamples.java
+++ b/src/main/java/com/web/stard/global/exception/ApiErrorCodeExamples.java
@@ -1,0 +1,16 @@
+package com.web.stard.global.exception;
+
+import com.web.stard.global.exception.error.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+
+    ErrorCode[] value();
+
+}

--- a/src/main/java/com/web/stard/global/exception/ExampleHolder.java
+++ b/src/main/java/com/web/stard/global/exception/ExampleHolder.java
@@ -1,0 +1,15 @@
+package com.web.stard.global.exception;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+
+}

--- a/src/main/java/com/web/stard/global/exception/ExampleHolder.java
+++ b/src/main/java/com/web/stard/global/exception/ExampleHolder.java
@@ -11,5 +11,6 @@ public class ExampleHolder {
     private Example holder;
     private String name;
     private int code;
+    private String description;
 
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #97 

## 📝 작업 내용
```
    @Operation(summary = "평가 등록", description = "평가 대상 회원 닉네임을 적어주세요.")
    @ApiErrorCodeExamples({
            ErrorCode.STUDY_NOT_FOUND,
            ErrorCode.STUDY_NOT_COMPLETED,
            ErrorCode.STUDY_EVALUATION_BAD_REQUEST,
            ErrorCode.DUPLICATE_STUDY_EVALUATION_REQUEST
    })
    @PostMapping
    public ResponseEntity<Long> createEvaluation(@CurrentMember Member member,
                                                 @PathVariable(name = "studyId") Long studyId,
                                                 @Valid @RequestBody EvaluationRequestDto.CreateDto requestDto) {
        return ResponseEntity.ok(evaluationService.createEvaluation(studyId, member, requestDto));
    }
```
각 메소드에 이런 식으로 추가해주면 아래와 같이 나옵니다 ! 
![image](https://github.com/user-attachments/assets/2987e2e7-0990-407a-a2d8-0dad04e9615d)


## 📚 Reference
- [[스프링] spring swagger 같은 코드 여러 에러 응답 예시 만들기](https://devnm.tistory.com/29)
- [[Spring] Swagger 공통 응답 코드 처리 및 Enum으로 정의한 응답 코드 사용하기](https://dsjo.tistory.com/6)
- ⭐ **[[Packy] Swagger @ApiResponses를 커스텀 어노테이션으로 대체하기](https://leeeeeyeon-dev.tistory.com/92#google_vignette)**

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ❓ 질문사항
![image](https://github.com/user-attachments/assets/3e61246e-298e-4bab-bcca-722e3d3c4b24)
이런 식으로 하면 이런 설명도 추가 가능하다는데 하는 게 좋을까요? 이 부분은 조금 더 찾아봐야 할 것 같긴한데..
![image](https://github.com/user-attachments/assets/d5c9e71a-ba90-415e-91f6-6a10d7c83950)


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
